### PR TITLE
Fixes hardcoded file separator in 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
   demonstrates how to log the groundtruth output from a simulation and
   save the results to a .csv file.
 
+### Fixed
+- Fixed a bug preventing the opening of a background file on Linux/Mac
+  OS that was caused by a hard-coded backslash file separator
+  character.
+
 ### Removed
 - Removed the script **example_run_generator_moving_from_csv.bsh** and
   made a comment about how to implement trajectory loading from an

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/obstructors/ConstantBackground.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/obstructors/ConstantBackground.java
@@ -106,7 +106,7 @@ public class ConstantBackground implements Obstructor  {
      */
     private void loadFile(File file) {
         Opener o = new Opener();
-        ImagePlus win = o.openTiff(file.getParent().concat("\\"),file.getName());
+        ImagePlus win = o.openTiff(file.getParent().concat(File.separator),file.getName());
         ImageStack stack = win.getImageStack();
         ImageProcessor ip = stack.getProcessor(1);
         FloatProcessor fp = ip.convertToFloatProcessor();


### PR DESCRIPTION
Fixed a bug preventing the opening of a background file on Linux/Mac OS that was caused by a hard-coded backslash file separator character.