### PR TITLE
Add 3D Gaussian PSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
   of PSF models used by SASS.
 - A `Gaussian3D` PSF class was added for modeling PSF's as a
   through-focus Gaussian beam.
+- Added new methods to FluorophoreGenerator and scripts for creating
+  3D fluorophore distributions.
 
 ### Changed
 - The Emitter, Fluorophore, and Camera API's have been changed to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
   positions in x, y, z to a file.
 - A `PSF` interface has been created to more easily extend the number
   of PSF models used by SASS.
+- A `Gaussian3D` PSF class was added for modeling PSF's as a
+  through-focus Gaussian beam.
 
 ### Changed
 - The Emitter, Fluorophore, and Camera API's have been changed to

--- a/scripts/example_grid_2d_fluorophores.bsh
+++ b/scripts/example_grid_2d_fluorophores.bsh
@@ -2,8 +2,8 @@
  * Copyright (C) 2017 Laboratory of Experimental Biophysics
  * Ecole Polytechnique Federale de Lausanne.
  *
- * This script demonstrates how to populate the field with a 2D
- * distribution of fluorophores arranged on a square grid.
+ * This script demonstrates how to randomly populate the field with
+ * with a 2D distribution of fluorophores.
  *
  */
 
@@ -12,7 +12,7 @@ import ch.epfl.leb.sass.simulator.generators.realtime.psfs.Gaussian2D;
 import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.PalmProperties;
 import java.util.ArrayList;
 
-RNG.setSeed(1);
+RNG.setSeed(5);
 
 // *** Initalize generator from the ground up ***
 Camera camera = new Camera(
@@ -50,8 +50,8 @@ double fwhm = camera.fwhm_digital; // From the Airy disk
 Gaussian2D gauss2D = new Gaussian2D(fwhm);
 
 // generate emitters 
-ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid2D(
-        4, // spacing in pixels
+ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom2D(
+        100, // number of fluorophores
 	camera,
 	gauss2D,
 	fluo);
@@ -85,4 +85,3 @@ for (i=0;i<10000;i++) {
 //ip.updateAndRepaintWindow();
 
 //System.exit(0); // uncomment if you want termination immediately
-

--- a/scripts/example_grid_3d_fluorophores.bsh
+++ b/scripts/example_grid_3d_fluorophores.bsh
@@ -1,34 +1,42 @@
 /**
- * This is a run without real-time laser control, good for simulating STORM data for use
- * by other programs.
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne.
+ *
+ * This script demonstrates how to populate the field with a 3D
+ * distribution of fluorophores arranged on a square grid. The axial
+ * positions of the fluorophores ascend in a step-wise fashion.
+ *
  */
 
-import ch.epfl.leb.sass.simulator.generators.realtime.*; // I am sorry
+import ch.epfl.leb.sass.simulator.generators.realtime.*;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.Gaussian3D;
 import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.PalmProperties;
 import java.util.ArrayList;
 
 RNG.setSeed(1);
 
 // *** Initalize generator from the ground up ***
-Camera camera = new Camera(300, //res_x
-                    300, //res_y
+Camera camera = new Camera(
+		    32, //res_x
+                    32, //res_y
                     100, //acq_speed, 
                     1.6, //readout_noise, 
                     0.06, //dark_current, 
                     0.8, //quantum_efficiency, 
-                    0.02,  // ADU_per_electron
-                    100,    // EM_gain
+                    2.2,  // ADU_per_electron
+                    0,    // EM_gain
                     100,  // baseline, ADU 
                     6.45 * 1e-6, //pixel_size, 
                     1.3, //NA, 
                     600 * 1e-9, //wavelength, 
-                    100); //magnification)
+                    60); //magnification)
 
 // fluorophores: all properties in units per frame
-FluorophoreProperties fluo = new PalmProperties(2500, // signal
-                    50, // background
-                    100.0, //ka
-                    0.0, // kb
+FluorophoreProperties fluo = new PalmProperties(
+		    2500, // photons per fluorophore
+                    50,   // background
+                    100,  //ka
+                    0,    // kb
                     7.8/1.2/100.0, // kd1
                     0.2*7.8/1.2/100.0, // kd2
                     0.4/100.0, //kr1
@@ -38,12 +46,19 @@ Laser laser = new Laser(0.0, // start
         500.0, // max
         0.0); // min
 
-// generate emitters 
-	// create a grid
-	ArrayList emitters = FluorophoreGenerator.generate3DFluorophoresGrid(10,// spacing in px
-				camera,
-				fluo);
+// Create a 2D Gaussian point-spread function
+double fwhm = camera.fwhm_digital; // From the Airy disk
+Gaussian3D gauss3D = new Gaussian3D(fwhm, camera.NA);
 
+// generate emitters 
+ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid3D(
+        4,  // spacing in pixels
+	-5, // Lower bound on z, pixels
+	5,  // Upper bound on z, pixels
+	camera,
+	gauss3D,
+	fluo);
+		
 // add a gold bead to the field of view at random location
 import ch.epfl.leb.sass.simulator.generators.realtime.obstructors.GoldBeads;
 ArrayList obstructors = new ArrayList();
@@ -58,7 +73,7 @@ STORMsim generator = new STORMsim(device);
 generator.setControlSignal(0.03);
 
 // simulate frames
-for (i=0;i<2500;i++) {
+for (i=0;i<10000;i++) {
     if (i%1000==0) {
 		System.out.println(i);
 	}
@@ -66,13 +81,11 @@ for (i=0;i<2500;i++) {
 }
 
 // save and show; uncomment these lines to save and display stack
-generator.saveStack(new File("generated_stack.tif"));
+//generator.saveStack(new File("generated_stack.tif"));
 //import ij.ImagePlus;
 //ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
 //ip.show();
 //ip.updateAndRepaintWindow();
 
 //System.exit(0); // uncomment if you want termination immediately
-
-
 

--- a/scripts/example_random_3d_fluorophores.bsh
+++ b/scripts/example_random_3d_fluorophores.bsh
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne.
+ *
+ * This script demonstrates how to randomly populate the field with
+ * with a 3D distribution of fluorophores.
+ *
+ */
+
+import ch.epfl.leb.sass.simulator.generators.realtime.*;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.Gaussian3D;
+import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.PalmProperties;
+import java.util.ArrayList;
+
+RNG.setSeed(5);
+
+// *** Initalize generator from the ground up ***
+Camera camera = new Camera(
+		    32, //res_x
+                    32, //res_y
+                    100, //acq_speed, 
+                    1.6, //readout_noise, 
+                    0.06, //dark_current, 
+                    0.8, //quantum_efficiency, 
+                    2.2,  // ADU_per_electron
+                    0,    // EM_gain
+                    100,  // baseline, ADU 
+                    6.45 * 1e-6, //pixel_size, 
+                    1.3, //NA, 
+                    600 * 1e-9, //wavelength, 
+                    60); //magnification)
+
+// fluorophores: all properties in units per frame
+FluorophoreProperties fluo = new PalmProperties(
+		    2500, // photons per fluorophore
+                    50,   // background
+                    100,  //ka
+                    0,    // kb
+                    7.8/1.2/100.0, // kd1
+                    0.2*7.8/1.2/100.0, // kd2
+                    0.4/100.0, //kr1
+                    15.7/100.0); // kr2
+// laser
+Laser laser = new Laser(0.0, // start
+        500.0, // max
+        0.0); // min
+
+// Create a 3D Gaussian point-spread function. The numerical aperture
+// is needed to compute the PSF's Rayleigh range.
+double fwhm = camera.fwhm_digital; // From the Airy disk
+Gaussian3D gauss3D = new Gaussian3D(fwhm, camera.NA);
+
+// generate emitters 
+ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom3D(
+        100, // number of fluorophores
+	-10,  // Lower bound on z (units are pixels)
+	10,   // Upper bound on z (units are pixels)
+	camera,
+	gauss3D,
+	fluo);
+		
+// add a gold bead to the field of view at random location
+import ch.epfl.leb.sass.simulator.generators.realtime.obstructors.GoldBeads;
+ArrayList obstructors = new ArrayList();
+Obstructor beads = new GoldBeads(1, camera, 3000);
+obstructors.add(beads);
+
+// assemble the device and generator
+Device device = new Device(camera, fluo, laser, emitters, obstructors);
+STORMsim generator = new STORMsim(device);
+
+// set laser power
+generator.setControlSignal(0.03);
+
+// simulate frames
+for (i=0;i<10000;i++) {
+    if (i%1000==0) {
+		System.out.println(i);
+	}
+	generator.getNextImage();
+}
+
+// save and show; uncomment these lines to save and display stack
+//generator.saveStack(new File("generated_stack.tif"));
+//import ij.ImagePlus;
+//ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
+//ip.show();
+//ip.updateAndRepaintWindow();
+
+//System.exit(0); // uncomment if you want termination immediately
+
+
+

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
@@ -150,4 +150,12 @@ public class Camera {
 
         fwhm_digital = airy_psf_radius_digital / pixel_size;
     }
+    
+    public int getRes_X() {
+        return this.res_x;
+    }
+    
+    public int getRes_Y() {
+        return this.res_y;
+    }
 }

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGenerator.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGenerator.java
@@ -89,6 +89,38 @@ public class FluorophoreGenerator {
     }
     
     /**
+     * Randomly populate the field of view with fluorophores in three dimensions.
+     * 
+     * @param numFluors The number of fluorophores to add to the field of view.
+     * @param zLow The lower bound on the range in z in units of pixels
+     * @param zHigh The upper bound on the range in z in units of pixels
+     * @param camera The camera for determining the size of the field of view.
+     * @param psf The PSF of the microscope.
+     * @param fluorProp The fluorophore dynamics properties.
+     * @return The list of fluorophores.
+     */
+    public static ArrayList<Fluorophore> generateFluorophoresRandom3D(
+            int numFluors,
+            double zLow,
+            double zHigh,
+            Camera camera,
+            PSF psf,
+            FluorophoreProperties fluorProp) {
+        Random rnd = RNG.getUniformGenerator();
+        ArrayList<Fluorophore> result = new ArrayList();
+        double x;
+        double y;
+        double z;
+        for (int i=0; i < numFluors; i++) {
+            x = camera.res_x * rnd.nextDouble();
+            y = camera.res_y * rnd.nextDouble();
+            z = (zHigh - zLow) * rnd.nextDouble() + zLow;
+            result.add(fluorProp.newFluorophore(psf, x, y, z));
+        }
+        return result;
+    }
+    
+    /**
      * Generate a rectangular grid of fluorophores
      * @param spacing distance between nearest neighbors
      * @param cam Camera

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGenerator.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGenerator.java
@@ -169,6 +169,16 @@ public class FluorophoreGenerator {
         return result;
     }
     
+    /**
+     * 
+     * @param spacing
+     * @param cam
+     * @param fluo
+     * @return
+     * @deprecated Use {@link #generateFluorophoresGrid3D(int, double, double, ch.epfl.leb.sass.simulator.generators.realtime.Camera, ch.epfl.leb.sass.simulator.generators.realtime.psfs.PSF, ch.epfl.leb.sass.simulator.generators.realtime.FluorophoreProperties) }
+     *           instead.
+     */
+    @Deprecated
     public static ArrayList<Fluorophore3D> generate3DFluorophoresGrid(int spacing, Camera cam, FluorophoreProperties fluo) {
         int limit_x = cam.res_x;
         int limit_y = cam.res_y;
@@ -176,6 +186,40 @@ public class FluorophoreGenerator {
         for (int i=spacing; i<limit_x; i+=spacing) {
             for (int j=spacing; j<limit_y; j+= spacing) {
                 result.add(fluo.createFluorophore3D(cam, i, j, ((-limit_y/2)+j)/100.0));
+            }
+        }       
+        return result;
+    }
+    
+    /**
+     * Create fluorophores on a 2D grid and step-wise in the axial direction.
+     * 
+     * @param spacing The distance along the grid between nearest neighbors.
+     * @param zLow The lower bound on the range in z in units of pixels.
+     * @param zHigh The upper bound on the range in z in units of pixels.
+     * @param camera The camera for determining the size of the field of view.
+     * @param psf The PSF of the microscope.
+     * @param fluorProp The fluorophore dynamics properties.
+     * @return The list of fluorophores.
+     */
+    public static ArrayList<Fluorophore> generateFluorophoresGrid3D(
+            int spacing,
+            double zLow,
+            double zHigh,
+            Camera camera,
+            PSF psf,
+            FluorophoreProperties fluorProp) {
+        int limitX = camera.getRes_X();
+        int limitY = camera.getRes_Y();
+        double numFluors = ((double) limitX - spacing) * ((double) limitY - spacing) / spacing / spacing;
+        double zSpacing  = (zHigh - zLow) / (numFluors - 1);
+        double z = zLow;
+        
+        ArrayList<Fluorophore> result = new ArrayList();
+        for (int i = spacing; i < limitX; i += spacing) {
+            for (int j = spacing; j < limitY; j += spacing) {
+                result.add(fluorProp.newFluorophore(psf, i, j, z));
+                z += zSpacing;
             }
         }       
         return result;

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+import ch.epfl.leb.sass.simulator.generators.realtime.Pixel;
+import static java.lang.Math.sqrt;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.math.MathException;
+import org.apache.commons.math.special.Erf;
+
+/**
+ * Generates a digital representation of a three-dimensional Gaussian PSF.
+ * 
+ * In this simple but unphysical model, the variance of the Gaussian PSF from
+ * an emitter at a distance z from the focal plane scales linearly with the
+ * amount of defocus.
+ * 
+ * @author Kyle M. Douglass
+ */
+public class Gaussian3D implements PSF {
+    
+    /**
+     * The FWHM of the in-focus Gaussian PSF.
+     */
+    private double FWHM;
+    
+    /**
+     * The numerical aperture of the microscope.
+     * 
+     * This determines the Rayleigh range of the of the Gaussian PSF.
+     */
+    private double numericalAperture;
+    
+    /**
+     * Creates an instance of the two-dimensional Gaussian PSF class with a given full width half maximum.
+     * @param fwhm The full width half maximum of the Gaussian at its waist.
+     *        [pixels]
+     */
+    public Gaussian3D(double fwhm, double numericalAperture) {
+        this.FWHM = fwhm;
+        this.numericalAperture = numericalAperture;
+    }
+    
+    /**
+     * Computes the relative probability of receiving a photon at pixel (pixelX, pixelY) from an emitter at
+     * (emitterX, emitterY, emitterZ).
+     * @param pixelX The pixel's x-position.
+     * @param pixelY The pixel's y-position.
+     * @param emitterX The emitter's x-position in fractions of a pixel.
+     * @param emitterY The emitter's y-position in fractions of a pixel.
+     * @param emitterZ The emitter's z-position in fractions of a pixel. This is ignored.
+     * @return The relative probability of a photon hitting this pixel.
+     * @throws org.apache.commons.math.MathException
+     */
+    @Override
+    public double generatePixelSignature(
+            int pixelX, 
+            int pixelY,
+            double emitterX,
+            double emitterY,
+            double emitterZ
+    ) throws MathException {
+        final double sigma_0 = this.FWHM / 2.3548;
+        final double zR = 2 * sigma_0 / this.numericalAperture; // Rayleigh range
+        double sigma = sigma_0 * sqrt(1 + (emitterZ / zR) * (emitterZ / zR));
+        double denom = sqrt(2.0)*sigma;
+        return 0.25 *(Erf.erf((pixelX - emitterX + 0.5)/denom) - 
+                      Erf.erf((pixelX - emitterX - 0.5)/denom)) *
+                     (Erf.erf((pixelY - emitterY + 0.5)/denom) -
+                      Erf.erf((pixelY - emitterY - 0.5)/denom));
+    }
+    
+    /**
+     * Generates the digital signature (the PSF) of the emitter on its nearby pixels.
+     * 
+     * @param pixels The list of pixels spanned by the emitter's image.
+     * @param emitterX The emitter's x-position [pixels]
+     * @param emitterY The emitter's x-position [pixels]
+     * @param emitterZ The emitter's x-position [pixels]
+     */
+    public void generateSignature(ArrayList<Pixel> pixels, double emitterX,
+                              double emitterY, double emitterZ) {
+        double signature;
+        for(Pixel pixel: pixels) {
+            try {
+                signature = this.generatePixelSignature(
+                        pixel.x, pixel.y, emitterX, emitterY, emitterZ);
+            } catch (MathException ex) {
+                signature = 0.0;
+                Logger.getLogger(Gaussian3D.class.getName()).log(Level.SEVERE, null, ex);
+            }
+            pixel.setSignature(signature);
+        }
+    }
+    
+    /**
+     * Computes the half-width of the PSF for determining which pixels contribute to the emitter signal.
+     * 
+     * The effective width used here is five times the standard deviation when
+     * the emitter is exactly in focus. The larger factor of five accounts for
+     * the larger lateral PSF size when it is out of focus.
+     * 
+     * @return The width of the PSF.
+     */
+    @Override
+    public double getRadius() {
+        final double sigma = this.FWHM / 2.3548;
+        // radius cutoff
+        final double r = 5 * sigma;
+        return r;
+    }
+    
+    public double getFWHM() {
+        return this.FWHM;
+    }
+    
+    public void setFWHM(double fwhm) {
+        this.FWHM = fwhm;
+    }
+    
+    public double getNumericalAperture() {
+        return this.numericalAperture;
+    }
+    
+    public void setNumericalAperture(double numericalAperture) {
+        this.numericalAperture = numericalAperture;
+    }
+}

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGeneratorTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/FluorophoreGeneratorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime;
+
+import java.util.ArrayList;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.Gaussian3D;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.PSF;
+import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.SimpleProperties;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import static org.mockito.Mockito.*;
+
+import java.awt.geom.Point2D;
+
+
+
+/**
+ *
+ * @author Kyle M. Douglass
+ */
+public class FluorophoreGeneratorTest {
+    
+    private Camera dummyCamera = null;
+    private PSF dummyPSF = null;
+    private FluorophoreGenerator fluorGen = new FluorophoreGenerator();
+    
+    // Mocking FluorophoreProperties proved a bit difficult, so I chose the
+    // least likely implementation to change in the future.
+    private FluorophoreProperties fluorProp = new SimpleProperties(2500, 50, 3, 100, 1000);
+    
+    public FluorophoreGeneratorTest() {
+        this.dummyCamera    = mock(Camera.class);
+        this.dummyPSF       = mock(Gaussian3D.class);
+    }
+
+    @Before
+    public void setUp () {
+        
+    }
+    
+    /**
+     * Test of generateFluorophoresGrid3D method, of class FluorophoreGenerator.
+     */
+    @Test
+    public void testGenerateFluorophoresGrid3D() {
+        // Setup a 32x32 pixel camera
+        int res_x = 32;
+        int res_y = 32;
+        when(this.dummyCamera.getRes_X()).thenReturn(res_x);
+        when(this.dummyCamera.getRes_Y()).thenReturn(res_y);
+
+        int spacing  = 4;
+        double zLow  = 4;
+        double zHigh = 10;
+        
+        ArrayList<Fluorophore> fluors = new ArrayList();
+        fluors = this.fluorGen.generateFluorophoresGrid3D(
+                spacing,
+                zLow,
+                zHigh,
+                dummyCamera,
+                dummyPSF,
+                this.fluorProp);
+
+        // There are ((32/4) - 1)^2 fluorophores
+        assertEquals((res_x - spacing) * (res_y - spacing) / spacing / spacing,
+                 fluors.size());
+        
+        // Check that the fluorophores span the correct range in z-values.
+        assertEquals(zLow, fluors.get(0).z, 0.0001);
+        assertEquals(zHigh, fluors.get(fluors.size() - 1).z, 0.0001);
+  
+    }
+
+}

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3DTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3DTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+import ch.epfl.leb.sass.simulator.generators.realtime.Pixel;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ *
+ * @author douglass
+ */
+public class Gaussian3DTest {
+    
+   private Gaussian3D gauss3d = null;
+   private final double fwhm = 3;
+   private final double numericalAperture = 1.3;
+    
+    @Before
+    public void setUp() {
+        this.gauss3d = new Gaussian3D(fwhm, numericalAperture);
+    }
+
+    /**
+     * Test of generatePixelSignature method, of class Gaussian3D.
+     */
+    @Test
+    public void testGeneratePixelSignatureInFocus() throws Exception {
+        // True answer and precision
+        double groundTruth = 0.0932;
+        double delta = 0.0001;
+        
+        // Find the relative probability of a photon hitting a pixel at (0,0)
+        // an emitter located at the pixel's center.
+        double signature = this.gauss3d.generatePixelSignature(0, 0, 0, 0, 0);
+        assertEquals(signature, groundTruth, delta);
+        
+        // Now test the signature for an emitter not centered on the pixel
+        groundTruth = 0.0849;
+        delta = 0.0001;
+        
+        // Find the relative probability of a photon hitting a pixel at (0,0)
+        // from an emitter located -.4 pixels from the pixel's center in x and y
+        signature = this.gauss3d.generatePixelSignature(0, 0, -0.4, -0.4, 0);
+        assertEquals(signature, groundTruth, delta);
+    }
+    
+    /**
+     * Test of generatePixelSignature method, of class Gaussian3D.
+     */
+    @Test
+    public void testGeneratePixelSignatureOutOfFocus() throws Exception {
+        // True answer and precision
+        double groundTruth = 0.0748;
+        double delta = 0.0001;
+        double z = 1; // units are pixels
+        
+        // Find the relative probability of a photon hitting a pixel at (0,0)
+        // from an emitter located at the pixel's center.
+        double signature = this.gauss3d.generatePixelSignature(0, 0, 0, 0, z);
+        assertEquals(signature, groundTruth, delta);
+        
+        // Now test the signature for an emitter not centered on the pixel
+        groundTruth = 0.0693;
+        delta = 0.0001;
+        
+        // Find the relative probability of a photon hitting a pixel at (0,0)
+        // an emitter located -.4 pixels from the pixel's center in x and y
+        signature = this.gauss3d.generatePixelSignature(0, 0, -0.4, -0.4, z);
+        assertEquals(signature, groundTruth, delta);
+    }
+    
+    /**
+     * Test of getSignature method, of class Gaussian2D.
+     */
+    @Test
+    public void testGetSignatureInFocus() {
+        // Test point at (0,0)
+        Point2D point = new Point2D.Double();
+        
+        // Emitter is at z = 1.0
+        double z = 1.0;
+        
+         // Ground-truth array
+        ArrayList<Pixel> groundTruth = new ArrayList();
+        groundTruth.add(new Pixel(-1,  0, 0.0591)); // (-1,  0)
+        groundTruth.add(new Pixel( 0, -1, 0.0591)); // ( 0, -1)
+        groundTruth.add(new Pixel( 0,  0, 0.0748)); // ( 0,  0)
+        groundTruth.add(new Pixel( 0,  1, 0.0591)); // ( 0,  1)
+        groundTruth.add(new Pixel( 1,  0, 0.0591)); // ( 1,  0)
+        
+        // Generate the test array whose signature values will be computed
+        ArrayList<Pixel> pixels = new ArrayList();
+        pixels.add(new Pixel(-1,  0, 0.0)); // (-1,  0)
+        pixels.add(new Pixel( 0, -1, 0.0)); // ( 0, -1)
+        pixels.add(new Pixel( 0,  0, 0.0)); // ( 0,  0)
+        pixels.add(new Pixel( 0,  1, 0.0)); // ( 0,  1)
+        pixels.add(new Pixel( 1,  0, 0.0)); // ( 1,  0)
+        
+        // Critical test occurs here
+        this.gauss3d.generateSignature(pixels, 0, 0, z);
+        
+        // Verify that the signatures in the pixel array match the ground truth
+        for (int ctr = 0; ctr < pixels.size(); ctr++)
+        {
+            assertEquals(groundTruth.get(ctr).getSignature(),
+                    pixels.get(ctr).getSignature(),
+                    0.0001);
+        }
+    }
+
+    /**
+     * Test of getRadius method, of class Gaussian2D.
+     */
+    @Test
+    public void testGetRadius() {
+        double actualRadius = 5 * 1.2740;
+        assertEquals(this.gauss3d.getRadius(), actualRadius, 0.0001);
+    }
+    
+    /**
+     * Test of getFWHM method, of class Gaussian2D.
+     */
+    @Test
+    public void testGetFWHM() {
+        assertEquals(this.gauss3d.getFWHM(), 3.0, 0.0001);
+    }
+
+    /**
+     * Test of setFWHM method, of class Gaussian2D.
+     */
+    @Test
+    public void testSetFWHM() {
+        this.gauss3d.setFWHM(5);
+        assertEquals(5, this.gauss3d.getFWHM(), 0.0001);
+    }
+    
+        /**
+     * Test of getFWHM method, of class Gaussian2D.
+     */
+    @Test
+    public void testGetNumericalAperture() {
+        assertEquals(this.gauss3d.getNumericalAperture(), numericalAperture, 0.0001);
+    }
+
+    /**
+     * Test of setFWHM method, of class Gaussian2D.
+     */
+    @Test
+    public void testSetNumericalAperture() {
+        this.gauss3d.setNumericalAperture(1.2);
+        assertEquals(1.2, this.gauss3d.getNumericalAperture(), 0.0001);
+    }
+    
+}


### PR DESCRIPTION
### Added
- A `Gaussian3D` PSF class was added for modeling PSF's as a through-focus Gaussian beam.
- Added new methods to FluorophoreGenerator and scripts for creating 3D fluorophore distributions.