### PR TITLE
Add Gibson-Lanni PSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v0.5.0]
+
+### Added
+- There is now a `GibsonLanniPSF` for modeling realistic 3D PSF's and
+  that can account for imaging details such as sample, coverslip, and
+  immersion media refractive indexes and thicknesses.
+- A `PSFBuilder` interface was added to allow for a PSF to be built at
+  various times during the simulation, rather than all at once. This
+  addition is necessary to account for axial stage positions that
+  might change during the simulation.
+    
 ## [v0.4.0]
 Contains [ALICA v0.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [v0.5.0]
+## [Unreleased]
 
 ### Added
 - There is now a `GibsonLanniPSF` for modeling realistic 3D PSF's and
-  that can account for imaging details such as sample, coverslip, and
+  that can account for details such as sample, coverslip, and
   immersion media refractive indexes and thicknesses.
 - A `PSFBuilder` interface was added to allow for a PSF to be built at
   various times during the simulation, rather than all at once. This

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ Placing the .jar file in `FIJI/plugins/` folder (file MUST have an underscore in
  - `Plugins -> SASS -> Command Prompt` launches BeanShell console. Generated images can be analyzed immediately with FIJI.
 
 ## Acknowledgements
-SASS uses adapted code and algorithms under GPL from following projects:
- - [SOFItool](https://github.com/lob-epfl/sofitool) by Arik Girsault and Tomas Lukes
- - [ALICA](https://github.com/MStefko/ALICA) by Marcel Stefko
- 
+
+SASS uses adapted code and algorithms from the following projects:
+ - [SOFItool](https://github.com/lob-epfl/sofitool) by Arik Girsault and Tomas Lukes (GPL)
+ - [ALICA](https://github.com/MStefko/ALICA) by Marcel Stefko (GPL)
+ - [MicroscPSF-ImageJ](https://github.com/hijizhou/MicroscPSF-ImageJ) by Jizhou Li (MIT)
  
  Many thanks to Dr. Kyle M. Douglass for guidance during this project.
 
-[Releases]: https://github.com/MStefko/SASS/releases
+[Releases]: https://github.com/LEB-EPFL/SASS/releases

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -17,8 +17,8 @@ RNG.setSeed(5);
 
 // *** Initalize generator from the ground up ***
 Camera camera = new Camera(
-		    32, //res_x
-                    32, //res_y
+		    64, //res_x
+                    64, //res_y
                     100, //acq_speed, 
                     1.6, //readout_noise, 
                     0.06, //dark_current, 
@@ -34,7 +34,7 @@ Camera camera = new Camera(
 // fluorophores: all properties in units per frame
 FluorophoreProperties fluo = new PalmProperties(
 		    2500, // photons per fluorophore
-                    50,   // background
+                    0,   // background
                     100,  //ka
                     0,    // kb
                     7.8/1.2/100.0, // kd1
@@ -52,8 +52,9 @@ int numSamples = 1000;
 int oversampling = 2;
 int sizeX = 256;
 int sizeY = 256;
-double NA = 1.4;
-double wavelength = 0.610;
+double NA = 1.3;
+double wavelength = 0.600;
+double magnification = 60;
 double ns = 1.33;
 double ng0 = 1.5;
 double ng = 1.5;
@@ -62,24 +63,25 @@ double ni = 1.5;
 double ti0 = 150;
 double tg0 = 170;
 double tg = 170;
-double resLateral = 0.100;
+double resLateral = 0.1075;
+double resPSF = 0.0215;
 double resAxial = 0.250;
-double pZ = 2;
         
 GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
 builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
        .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
        .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
-       .resAxial(resAxial).resLateral(resLateral).pZ(pZ)
-       .oversampling(oversampling);
+       .resAxial(resAxial).resLateral(resLateral)
+       .oversampling(oversampling).magnification(magnification)
+       .resPSF(resPSF);
 		
 GibsonLanniPSF psf = builder.build();
 
 // generate emitters
-ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom3D(
-        20, // number of fluorophores
+ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid3D(
+        8, // number of fluorophores
 	0,  // Lower bound on z (units are pixels)
-	3,   // Upper bound on z (units are pixels)
+	4,   // Upper bound on z (units are pixels)
 	camera,
 	psf,
 	fluo);

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -47,41 +47,39 @@ Laser laser = new Laser(0.0, // start
         0.0); // min
 
 // Create a Gibson-Lanni point spread function.
-int numBasis = 100;
+int numBasis   = 100;
 int numSamples = 1000;
 int oversampling = 2;
-int sizeX = 256;
-int sizeY = 256;
+int sizeX = 1024;
+int sizeY = 1024;
 double NA = 1.3;
-double wavelength = 0.600;
+double wavelength    = 0.600;
 double magnification = 60;
-double ns = 1.33;
+double ns  = 1.33;
 double ng0 = 1.5;
-double ng = 1.5;
+double ng  = 1.5;
 double ni0 = 1.5;
-double ni = 1.5;
+double ni  = 1.5;
 double ti0 = 150;
 double tg0 = 170;
-double tg = 170;
+double tg  = 170;
 double resLateral = 0.1075;
-double resPSF = 0.0215;
-double resAxial = 0.250;
+double resPSF = 0.00215;
         
 GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
 builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
        .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
        .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
-       .resAxial(resAxial).resLateral(resLateral)
-       .oversampling(oversampling).magnification(magnification)
+       .resLateral(resLateral).oversampling(oversampling)
        .resPSF(resPSF);
 		
 GibsonLanniPSF psf = builder.build();
 
 // generate emitters
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid3D(
-        8, // number of fluorophores
+        16, // spacing
 	0,  // Lower bound on z (units are pixels)
-	4,   // Upper bound on z (units are pixels)
+	5,  // Upper bound on z (units are pixels)
 	camera,
 	psf,
 	fluo);

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne.
+ *
+ * This script demonstrates how to randomly populate the field with
+ * with a 3D distribution of fluorophores whose images are computed
+ * according to the Gibson-Lanni PSF>
+ *
+ */
+
+import ch.epfl.leb.sass.simulator.generators.realtime.*;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.GibsonLanniPSF;
+import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.PalmProperties;
+import java.util.ArrayList;
+
+RNG.setSeed(5);
+
+// *** Initalize generator from the ground up ***
+Camera camera = new Camera(
+		    32, //res_x
+                    32, //res_y
+                    100, //acq_speed, 
+                    1.6, //readout_noise, 
+                    0.06, //dark_current, 
+                    0.8, //quantum_efficiency, 
+                    2.2,  // ADU_per_electron
+                    0,    // EM_gain
+                    100,  // baseline, ADU 
+                    6.45 * 1e-6, //pixel_size, 
+                    1.3, //NA, 
+                    600 * 1e-9, //wavelength, 
+                    60); //magnification)
+
+// fluorophores: all properties in units per frame
+FluorophoreProperties fluo = new PalmProperties(
+		    2500, // photons per fluorophore
+                    50,   // background
+                    100,  //ka
+                    0,    // kb
+                    7.8/1.2/100.0, // kd1
+                    0.2*7.8/1.2/100.0, // kd2
+                    0.4/100.0, //kr1
+                    15.7/100.0); // kr2
+// laser
+Laser laser = new Laser(0.0, // start
+        500.0, // max
+        0.0); // min
+
+// Create a Gibson-Lanni point spread function.
+int numBasis = 100;
+int numSamples = 1000;
+int oversampling = 2;
+int sizeX = 256;
+int sizeY = 256;
+double NA = 1.4;
+double wavelength = 0.610;
+double ns = 1.33;
+double ng0 = 1.5;
+double ng = 1.5;
+double ni0 = 1.5;
+double ni = 1.5;
+double ti0 = 150;
+double tg0 = 170;
+double tg = 170;
+double resLateral = 0.100;
+double resAxial = 0.250;
+double pZ = 2;
+        
+GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
+builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
+       .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
+       .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
+       .resAxial(resAxial).resLateral(resLateral).pZ(pZ)
+       .oversampling(oversampling);
+		
+GibsonLanniPSF psf = builder.build();
+
+// generate emitters
+ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom3D(
+        20, // number of fluorophores
+	0,  // Lower bound on z (units are pixels)
+	3,   // Upper bound on z (units are pixels)
+	camera,
+	psf,
+	fluo);
+		
+// add a gold bead to the field of view at random location
+import ch.epfl.leb.sass.simulator.generators.realtime.obstructors.GoldBeads;
+ArrayList obstructors = new ArrayList();
+Obstructor beads = new GoldBeads(1, camera, 3000);
+obstructors.add(beads);
+
+// assemble the device and generator
+Device device = new Device(camera, fluo, laser, emitters, obstructors);
+STORMsim generator = new STORMsim(device);
+
+// set laser power
+generator.setControlSignal(0.03);
+
+// simulate frames
+for (i=0;i<10000;i++) {
+    if (i%1000==0) {
+		System.out.println(i);
+	}
+	generator.getNextImage();
+}
+
+// save and show; uncomment these lines to save and display stack
+generator.saveStack(new File("generated_stack.tif"));
+//import ij.ImagePlus;
+//ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
+//ip.show();
+//ip.updateAndRepaintWindow();
+
+//System.exit(0); // uncomment if you want termination immediately
+
+
+

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -106,7 +106,7 @@ for (i=0;i<10000;i++) {
 }
 
 // save and show; uncomment these lines to save and display stack
-generator.saveStack(new File("generated_stack.tif"));
+//generator.saveStack(new File("generated_stack.tif"));
 //import ij.ImagePlus;
 //ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
 //ip.show();

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -54,7 +54,6 @@ int sizeX = 1024;
 int sizeY = 1024;
 double NA = 1.3;
 double wavelength    = 0.600;
-double magnification = 60;
 double ns  = 1.33;
 double ng0 = 1.5;
 double ng  = 1.5;
@@ -64,22 +63,26 @@ double ti0 = 150;
 double tg0 = 170;
 double tg  = 170;
 double resLateral = 0.1075;
-double resPSF = 0.00215;
+double resPSF = 0.0215;
+
+// A negative displacement means to move the stage down in an
+// inverted microscope.
+double stageDisplacement = -2; 
         
 GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
 builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
        .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
        .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
        .resLateral(resLateral).oversampling(oversampling)
-       .resPSF(resPSF);
+       .resPSF(resPSF).stageDisplacement(stageDisplacement);
 		
 GibsonLanniPSF psf = builder.build();
 
 // generate emitters
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid3D(
-        16, // spacing
+        8, // spacing
 	0,  // Lower bound on z (units are pixels)
-	5,  // Upper bound on z (units are pixels)
+	4,  // Upper bound on z (units are pixels)
 	camera,
 	psf,
 	fluo);
@@ -98,15 +101,15 @@ STORMsim generator = new STORMsim(device);
 generator.setControlSignal(0.03);
 
 // simulate frames
-for (i=0;i<10000;i++) {
-    if (i%1000==0) {
+for (i=0;i<1000;i++) {
+    if (i%200==0) {
 		System.out.println(i);
 	}
 	generator.getNextImage();
 }
 
 // save and show; uncomment these lines to save and display stack
-//generator.saveStack(new File("generated_stack.tif"));
+generator.saveStack(new File("generated_stack.tif"));
 //import ij.ImagePlus;
 //ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
 //ip.show();

--- a/scripts/example_dSTORM.bsh
+++ b/scripts/example_dSTORM.bsh
@@ -47,8 +47,9 @@ Laser laser = new Laser(
     0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian2D gauss2D = new Gaussian2D(fwhm);
+Gaussian2D.Builder builder = new Gaussian2D.Builder();
+builder.FWHM(camera.fwhm_digital); // From the Airy disk
+Gaussian2D gauss2D = builder.build();
 
 // generate emitters 
 // create a grid

--- a/scripts/example_grid_2d_fluorophores.bsh
+++ b/scripts/example_grid_2d_fluorophores.bsh
@@ -46,8 +46,9 @@ Laser laser = new Laser(0.0, // start
         0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian2D gauss2D = new Gaussian2D(fwhm);
+Gaussian2D.Builder builder = new Gaussian2D.Builder();
+builder.FWHM(camera.fwhm_digital); // From the Airy disk
+Gaussian2D gauss2D = builder.build();
 
 // generate emitters 
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom2D(

--- a/scripts/example_grid_3d_fluorophores.bsh
+++ b/scripts/example_grid_3d_fluorophores.bsh
@@ -47,8 +47,9 @@ Laser laser = new Laser(0.0, // start
         0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian3D gauss3D = new Gaussian3D(fwhm, camera.NA);
+Gaussian3D.Builder builder = new Gaussian3D.Builder();
+builder.FWHM(camera.fwhm_digital).NA(camera.NA); // From the Airy disk
+Gaussian3D gauss3D = builder.build();
 
 // generate emitters 
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresGrid3D(

--- a/scripts/example_loggers.bsh
+++ b/scripts/example_loggers.bsh
@@ -57,8 +57,9 @@ Laser laser = new Laser(
     0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian2D gauss2D = new Gaussian2D(fwhm);
+Gaussian2D.Builder builder = new Gaussian2D.Builder();
+builder.FWHM(camera.fwhm_digital);
+Gaussian2D gauss2D = builder.build();
 
 // generate emitters 
 // create a grid

--- a/scripts/example_random_2d_fluorophores.bsh
+++ b/scripts/example_random_2d_fluorophores.bsh
@@ -46,8 +46,9 @@ Laser laser = new Laser(0.0, // start
         0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian2D gauss2D = new Gaussian2D(fwhm);
+Gaussian2D.Builder builder = new Gaussian2D.Builder();
+builder.FWHM(camera.fwhm_digital); // From the Airy disk
+Gaussian2D gauss2D = builder.build();
 
 // generate emitters 
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom2D(

--- a/scripts/example_random_3d_fluorophores.bsh
+++ b/scripts/example_random_3d_fluorophores.bsh
@@ -47,8 +47,10 @@ Laser laser = new Laser(0.0, // start
 
 // Create a 3D Gaussian point-spread function. The numerical aperture
 // is needed to compute the PSF's Rayleigh range.
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian3D gauss3D = new Gaussian3D(fwhm, camera.NA);
+Gaussian3D.Builder builder = new Gaussian3D.Builder();
+builder.FWHM(camera.fwhm_digital); // From the Airy disk
+builder.NA(camera.NA);
+Gaussian3D gauss3D = builder.build();
 
 // generate emitters 
 ArrayList emitters = FluorophoreGenerator.generateFluorophoresRandom3D(

--- a/scripts/example_read_from_csv.bsh
+++ b/scripts/example_read_from_csv.bsh
@@ -42,8 +42,9 @@ Laser laser = new Laser(
     0.0); // min
 
 // Create a 2D Gaussian point-spread function
-double fwhm = camera.fwhm_digital; // From the Airy disk
-Gaussian2D gauss2D = new Gaussian2D(fwhm);
+Gaussian2D.Builder builder = new Gaussian2D.Builder();
+builder.FWHM(camera.fwhm_digital); // From the Airy disk
+Gaussian2D gauss2D = builder.build();
 
 // generate emitters
 File csv_file = new File("label_pix_sass.csv");
@@ -57,12 +58,12 @@ STORMsim generator = new STORMsim(device);
 generator.setControlSignal(0.01);
 
 // simulate frames
-for (i=0;i<10000;i++) {
-    if (i%1000==0) {
+for (i=0;i<1000;i++) {
+    if (i%200==0) {
 		System.out.println(i);
 	}
 	generator.getNextImage();
 }
 
 // Save the stack
-generator.saveStack(new File("generated_stack.tif"));
+//generator.saveStack(new File("generated_stack.tif"));

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
@@ -108,6 +108,16 @@ public class Camera {
     public final int res_y;
     
     /**
+     * Displacement of the coverslip surface from the objective's focal plane.
+     * 
+     * This value assumes that the microscope objective is inverted (facing up)
+     * and that the axial direction is positive going upwards. A negative value
+     * therefore implies that the coverslip has been moved down towards the
+     * objective bringing objects located above the coverslip into focus.
+     */
+    public double stagePosition = 0;
+    
+    /**
      * Initialize camera with parameters.
      * @param res_x horizontal resolution [pixels]
      * @param res_y vertical resolution [pixels]

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Emitter.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Emitter.java
@@ -133,6 +133,7 @@ public abstract class Emitter extends Point2D.Double  {
     public Emitter(double x, double y, double z, PSF psf) {
         super(x, y);
         this.z = z;
+        // TODO: Pass a PSF builder to the emitter and build the PSF here.
         this.psf = psf;
         this.poisson = RNG.getPoissonGenerator();
         this.camera = null;

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2D.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2D.java
@@ -35,11 +35,30 @@ public class Gaussian2D implements PSF {
     private double FWHM;
     
     /**
-     * Creates an instance of the two-dimensional Gaussian PSF class with a given full width half maximum.
-     * @param fwhm The full width half maximum of the Gaussian. [pixels]
+     * The builder for constructing Gaussian2D instances.
      */
-    public Gaussian2D(double fwhm) {
-        this.FWHM = fwhm;
+    public static class Builder implements PSFBuilder {
+        
+        // Properties of the 2D Gaussian PSF model
+        private double FWHM;
+        
+        public Builder FWHM(double fwhm) {this.FWHM = fwhm; return this;}
+        
+        @Override
+        public Gaussian2D build() {
+            return new Gaussian2D(this);
+        }
+    }
+    
+    /**
+     * Creates an instance of the two-dimensional Gaussian PSF class with a given full width half maximum.
+     * 
+     * Creation of the instance is possible only through the Builder.
+     * 
+     * @param builder A Gaussian2D.Builder for constructing the PSF.
+     */
+    private Gaussian2D(Builder builder) {
+        this.FWHM = builder.FWHM;
     }
     
     /**

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2D.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2D.java
@@ -50,7 +50,7 @@ public class Gaussian2D implements PSF {
      * @param emitterX The emitter's x-position in fractions of a pixel.
      * @param emitterY The emitter's y-position in fractions of a pixel.
      * @param emitterZ The emitter's z-position in fractions of a pixel. This is ignored.
-     * @return The relative probability of a photon hitting this pixel.
+     * @return The probability of a photon hitting this pixel.
      * @throws org.apache.commons.math.MathException
      */
     @Override

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
@@ -66,7 +66,7 @@ public class Gaussian3D implements PSF {
      * @param emitterX The emitter's x-position in fractions of a pixel.
      * @param emitterY The emitter's y-position in fractions of a pixel.
      * @param emitterZ The emitter's z-position in fractions of a pixel. This is ignored.
-     * @return The relative probability of a photon hitting this pixel.
+     * @return The probability of a photon hitting this pixel.
      * @throws org.apache.commons.math.MathException
      */
     @Override

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3D.java
@@ -37,7 +37,7 @@ import org.apache.commons.math.special.Erf;
 public class Gaussian3D implements PSF {
     
     /**
-     * The FWHM of the in-focus Gaussian PSF.
+     * The FWHM of the in-focus Gaussian PSF. [pixels]
      */
     private double FWHM;
     
@@ -49,13 +49,33 @@ public class Gaussian3D implements PSF {
     private double numericalAperture;
     
     /**
-     * Creates an instance of the two-dimensional Gaussian PSF class with a given full width half maximum.
-     * @param fwhm The full width half maximum of the Gaussian at its waist.
-     *        [pixels]
+     * The builder for constructing Gaussian2D instances.
      */
-    public Gaussian3D(double fwhm, double numericalAperture) {
-        this.FWHM = fwhm;
-        this.numericalAperture = numericalAperture;
+    public static class Builder implements PSFBuilder {
+        
+        // Properties of the 3D Gaussian PSF model
+        private double FWHM;
+        private double numericalAperture;
+        
+        public Builder FWHM(double fwhm) {this.FWHM = fwhm; return this;}
+        public Builder NA(double NA) {this.numericalAperture = NA; return this;}
+        
+        @Override
+        public Gaussian3D build() {
+            return new Gaussian3D(this);
+        }
+    }
+    
+    /**
+     * Creates an instance of the two-dimensional Gaussian PSF class with a given full width half maximum.
+     * 
+     * Creation of the instance is possible only through the Builder.
+     * 
+     * @param builder A Gaussian3D.Builder for constructing the PSF.
+     */
+    private Gaussian3D(Builder builder) {
+        this.FWHM = builder.FWHM;
+        this.numericalAperture = builder.numericalAperture;
     }
     
     /**

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -334,7 +334,7 @@ public class GibsonLanniPSF implements PSF {
      * 
      * @return An image stack of the PSF.
      **/
-    public ImageStack computeDigitalPSF(double z) {
+    private ImageStack computeDigitalPSF(double z) {
         double x0 = (this.sizeX - 1) / 2.0D;
         double y0 = (this.sizeY - 1) / 2.0D;
 

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -268,10 +268,14 @@ public class GibsonLanniPSF implements PSF {
             double emitterZ
     ) {
         double scalingFactor = this.resLateral;
-        return this.interpCDF.value((pixelX - emitterX + 0.5) * scalingFactor, (pixelY - emitterY + 0.5) * scalingFactor) +
-               this.interpCDF.value((pixelX - emitterX - 0.5) * scalingFactor, (pixelY - emitterY - 0.5) * scalingFactor) -
-               this.interpCDF.value((pixelX - emitterX + 0.5) * scalingFactor, (pixelY - emitterY - 0.5) * scalingFactor) -
-               this.interpCDF.value((pixelX - emitterX - 0.5) * scalingFactor, (pixelY - emitterY + 0.5) * scalingFactor);
+        return this.interpCDF.value((pixelX - emitterX + 0.5) * scalingFactor,
+                                    (pixelY - emitterY + 0.5) * scalingFactor) +
+               this.interpCDF.value((pixelX - emitterX - 0.5) * scalingFactor,
+                                    (pixelY - emitterY - 0.5) * scalingFactor) -
+               this.interpCDF.value((pixelX - emitterX + 0.5) * scalingFactor,
+                                    (pixelY - emitterY - 0.5) * scalingFactor) -
+               this.interpCDF.value((pixelX - emitterX - 0.5) * scalingFactor,
+                                    (pixelY - emitterY + 0.5) * scalingFactor);
     }
     
         /**

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -154,7 +154,6 @@ public class GibsonLanniPSF implements PSF {
      */
     private final double MINWAVELENGTH = 0.436;
     
-    
     /**
      * The spline representation of the PSF.
      */

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -274,7 +274,7 @@ public class GibsonLanniPSF implements PSF {
                               double emitterY, double emitterZ) {
         double signature;
         this.pZ = emitterZ;
-        this.computeDigitalPSF(-5); // Compute the PSF; TODO: Allow stage displacement
+        this.computeDigitalPSF(-2.5); // Compute the PSF; TODO: Allow stage displacement
         for(Pixel pixel: pixels) {
             try {
                 signature = this.generatePixelSignature(
@@ -339,8 +339,8 @@ public class GibsonLanniPSF implements PSF {
         BesselJ bj1 = new BesselJ(1);
 
         for (int m = 0; m < this.numBasis; m++) {
-//			am = (3 * m + 1) * factor;
-                am = (3 * m + 1);
+		am = (3 * m + 1) * factor;
+//                am = (3 * m + 1);
                 for (int rhoi = 0; rhoi < this.numSamples; rhoi++) {
                         rho = rhoi * deltaRho;
                         Basis[rhoi][m] = bj0.value(am * rho);
@@ -371,7 +371,7 @@ public class GibsonLanniPSF implements PSF {
                 OPD += ti * Math.sqrt(this. ni * this.ni - rhoNA2) - this.ti0 * Math.sqrt(this.ni0 * this.ni0 - rhoNA2);
 
                 // OPD in the coverslip
-                OPD += this.tg * Math.sqrt(this.ng * this.ng - rhoNA2) * this.tg0 * Math.sqrt(this.ng0 * this.ng0 - rhoNA2);
+                OPD += this.tg * Math.sqrt(this.ng * this.ng - rhoNA2) - this.tg0 * Math.sqrt(this.ng0 * this.ng0 - rhoNA2);
 
                 W = k0 * OPD;
 

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+/**
+ * Computes an emitter PSF based on the Gibson-Lanni model.
+ * 
+ * @author Kyle M. Douglass
+ */
+public class GibsonLanniPSF { //TODO: impelements PSF
+    
+    /**
+     * The number of rescaled Bessel functions to approximate the pupil.
+     */
+    private int numBasis = 100;
+    
+    /**
+     * Number of samples along the pupil in the radial direction.
+     */
+    private int numSamples = 1000;
+    
+    /**
+     * The upsampling ratio on the image space grid.
+     */
+    private int upsampling = 2;
+    
+    /**
+     * Numerical aperture of the microscope.
+     */
+    private double NA = 1.4;
+    
+    /**
+     * The wavelength of light [microns].
+     */
+    private double wavelength = 0.610;
+    
+    /**
+     * The microscope magnification.
+     */
+    private double magnification = 100;
+    
+    /**
+     * The refractive index of the sample.
+     */
+    private double ns = 1.33;
+    
+    /**
+     * The design value for the coverslip refractive index.
+     */
+    private double ng0 = 1.5;
+    
+    /**
+     * The actual value for the coverslip refractive index.
+     */
+    private double ng = 1.5;
+    
+    /**
+     * The design value for the immersion medium refractive index.
+     */
+    private double ni0 = 1.5;
+    
+    /**
+     * The actual value for the immersion medium refractive index.
+     */
+    private double ni = 1.5;
+    
+    /**
+     * The design value for the immersion medium thickness [microns].
+     */
+    private double ti0 = 150;
+    
+    /**
+     * The design value for the coverslip thickness [microns].
+     */
+    private double tg0 = 170;
+    
+    /**
+     * The actual value for the coverslip thickness [microns].
+     */
+    private double tg = 170;
+    
+    /**
+     * The pixel size in the lateral direction [microns].
+     */
+    private double resLateral = 0.1;
+    
+    /**
+     * The pixel size in the axial direction [microns].
+     */
+    private double resAxial = 0.25;
+    
+    /**
+     * The emitter distance from the coverslip [microns].
+     */
+    private double pZ = 0;
+    
+    /**
+     * Determines the scaling factor for the basis Bessel functions [microns].
+     * See Li, J., Xue, F., & Blu, T. (2017). JOSA A, 34(6), 1029-1034 for more
+     * information.
+     */
+    public final double MINWAVELENGTH = 0.436;
+    
+    /**
+     * The scaling factor for the basis Bessel functions.
+     */
+    private double scalingFactor;
+    
+    public static class Builder {
+        
+        // Properties of the Gibson-Lanni PSF model
+        private int numBasis;
+        private int numSamples;
+        private int oversampling;
+        private int sizeX;
+        private int sizeY;
+        private int sizeZ;
+        private double NA;
+        private double wavelength;
+        private double magnification;
+        private double ns;
+        private double ng0;
+        private double ng;
+        private double ni0;
+        private double ni;
+        private double ti0;
+        private double tg0;
+        private double tg;
+        private double resLateral;
+        private double resAxial;
+        private double pZ;
+        
+        public Builder numBasis(int numBasis) {
+            this.numBasis = numBasis;
+            return this;
+        }
+        public Builder numSamples(int numSamples) {
+            this.numSamples = numSamples;
+            return this;
+        }
+        public Builder sizeX(int sizeX) {this.sizeX = sizeX; return this;}
+        public Builder sizeY(int sizeY) {this.sizeY = sizeY; return this;}
+        public Builder sizeZ(int sizeZ) {this.sizeZ = sizeZ; return this;}
+        public Builder NA(double NA) {this.NA = NA; return this;}
+        public Builder wavelength(double wavelength) {
+            this.wavelength = wavelength; return this;
+        }
+        public Builder magnification(double magnification) {
+            this.magnification = magnification;
+            return this;
+        }
+        public Builder ns(double ns) {this.ns = ns; return this;}
+        public Builder ng0(double ng0) {this.ng0 = ng0; return this;}
+        public Builder ng(double ng) {this.ng = ng; return this;}
+        public Builder ni0(double ni0) {this.ni0 = ni0; return this;}
+        public Builder ni(double ni) {this.ni = ni; return this;}
+        public Builder ti0(double ti0) {this.ti0 = ti0; return this;}
+        public Builder tg0(double tg0) {this.tg0 = tg0; return this;}
+        public Builder tg(double tg) {this.tg = tg; return this;}
+        public Builder resLateral(double resLateral) {
+            this.resLateral = resLateral; return this;
+        }
+        public Builder resAxial(double resAxial) {
+            this.resAxial = resAxial;
+            return this;
+        }
+        public Builder pZ(double pZ) {this.pZ = pZ; return this;}
+    }
+}

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -247,6 +247,10 @@ public class GibsonLanniPSF implements PSF {
         this.resPSF = builder.resPSF;
         this.pZ = builder.pZ;
         this.stageDisplacement = builder.stageDisplacement;
+        
+        // This is necessary to initialize interpCDF in case
+        // generatePixelSignature() is called before generateSignature()
+        this.computeDigitalPSF(this.stageDisplacement);
     }
     
     /**
@@ -290,6 +294,11 @@ public class GibsonLanniPSF implements PSF {
     public void generateSignature(ArrayList<Pixel> pixels, double emitterX,
                               double emitterY, double emitterZ) {
         double signature;
+        
+        // Setting pZ and the spline interpolation mean that this instance is
+        // mutable. In the future, consider making it completely immutable by
+        // forcing pZ to be set only through the builder and by interpolating
+        // the PSF in z as well so that it's precomputed.
         this.pZ = emitterZ;
         this.computeDigitalPSF(this.stageDisplacement); // Compute the PSF
         for(Pixel pixel: pixels) {

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -35,8 +35,8 @@ import java.util.logging.Logger;
 /**
  * Computes an emitter PSF based on the Gibson-Lanni model.
  * 
- * This algorithm was first described in Li, J., Xue, F., & Blu, T. (2017). Fast
- * and accurate three-dimensional point spread function computation for
+ * This algorithm was first described in Li, J., Xue, F., and Blu, T. (2017).
+ * Fast and accurate three-dimensional point spread function computation for
  * fluorescence microscopy. JOSA A, 34(6), 1029-1034.
  * 
  * The code is adapted from MicroscPSF-ImageJ by Jizhou Li:

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/PSFBuilder.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/PSFBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+/**
+ * Defines the Builder interface for constructing PSFs.
+ * 
+ * @author Kyle M. Douglass
+ */
+public interface PSFBuilder {
+    /**
+     * Builds a new instance of the PSF model.
+     * 
+     * @return The PSF model.
+     */
+    public PSF build();
+}

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/PSFBuilder.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/PSFBuilder.java
@@ -20,6 +20,14 @@ package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
 /**
  * Defines the Builder interface for constructing PSFs.
  * 
+ * Passing Builders instances, rather than PSF instances, to the simulation
+ * allows the PSF to be constructed at different times during the simulation.
+ * For example, one might set basic parameters like the wavelength in the
+ * beginning of the simulation and set the emitter's z-position immediately
+ * before a frame is computed. This means the simulation can dynamically create
+ * new PSF instances in response to changing simulation parameters.
+ * 
+ * 
  * @author Kyle M. Douglass
  */
 public interface PSFBuilder {

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2DTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian2DTest.java
@@ -35,7 +35,9 @@ public class Gaussian2DTest {
     @Before
     public void setUp() {
         double fwhm = 3;
-        this.gauss2d = new Gaussian2D(fwhm);
+        Gaussian2D.Builder builder = new Gaussian2D.Builder();
+        builder.FWHM(fwhm);
+        this.gauss2d = builder.build();
     }
 
     /**

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3DTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/Gaussian3DTest.java
@@ -36,7 +36,9 @@ public class Gaussian3DTest {
     
     @Before
     public void setUp() {
-        this.gauss3d = new Gaussian3D(fwhm, numericalAperture);
+        Gaussian3D.Builder builder = new Gaussian3D.Builder();
+        builder.FWHM(fwhm).NA(numericalAperture);
+        this.gauss3d = builder.build();
     }
 
     /**

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
@@ -17,9 +17,13 @@
  */
 package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
 
+import ch.epfl.leb.sass.simulator.generators.realtime.Pixel;
+import java.awt.geom.Point2D;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  *  Tests for the GibsonLanniPSF class.
@@ -27,7 +31,7 @@ import static org.junit.Assert.*;
  * @author Kyle M. Douglass
  */
 public class GibsonLanniPSFTest {
-    private GibsonLanniPSF psf = null;
+    private GibsonLanniPSF psf;
     
     public GibsonLanniPSFTest() {
     }
@@ -71,6 +75,18 @@ public class GibsonLanniPSFTest {
      */
     @Test
     public void testGeneratePixelSignature() {
+        // True answers and precision
+        double groundTruth = 0.02800;
+        double delta = 0.0001;
+
+        // Find the relative probability of a photon hitting a pixel at (0,0)
+        // an emitter located at the pixel's center.
+        double signature = this.psf.generatePixelSignature(0, 0, 0, -1, 0);
+        assertEquals(groundTruth, signature, delta);
+        
+        groundTruth = 0.03726;
+        signature = this.psf.generatePixelSignature(1, 1, 1, 1, 0);
+        assertEquals(groundTruth, signature, delta);
     }
 
     /**
@@ -78,6 +94,41 @@ public class GibsonLanniPSFTest {
      */
     @Test
     public void testGenerateSignature() {
+        // Precision
+        double delta = 0.0001;
+
+        // Test point at (0,0)
+        Point2D point = new Point2D.Double();
+        
+         // Ground-truth array
+         // Note that the ground truth is not symmetric about the center pixel
+         // because of the finite sampling of the CDF; it becomes more symmetric
+         // the smaller resPSF is and the larger sizeX/Y are.
+        ArrayList<Pixel> groundTruth = new ArrayList();
+        groundTruth.add(new Pixel( 1,  1, 0.03726)); // ( 1,  1)
+        groundTruth.add(new Pixel( 2,  1, 0.02800)); // ( 2,  1)
+        groundTruth.add(new Pixel( 0,  1, 0.03078)); // ( 0,  1)
+        groundTruth.add(new Pixel( 1,  2, 0.02800)); // ( 1,  2)
+        groundTruth.add(new Pixel( 1,  0, 0.03078)); // ( 1,  0)
+        
+        // Generate the test array whose signature values will be computed
+        ArrayList<Pixel> pixels = new ArrayList();
+        pixels.add(new Pixel( 1,  1, 0.0)); // ( 1,  1)
+        pixels.add(new Pixel( 2,  1, 0.0)); // ( 2,  1)
+        pixels.add(new Pixel( 0,  1, 0.0)); // ( 0,  1)
+        pixels.add(new Pixel( 1,  2, 0.0)); // ( 1,  2)
+        pixels.add(new Pixel( 1,  0, 0.0)); // ( 1,  0)
+        
+        // Critical test occurs here
+        this.psf.generateSignature(pixels, 1, 1, 2);
+        
+        // Verify that the signatures in the pixel array match the ground truth
+        for (int ctr = 0; ctr < pixels.size(); ctr++)
+        {
+            assertEquals(groundTruth.get(ctr).getSignature(),
+                    pixels.get(ctr).getSignature(),
+                    delta);
+        }
     }
 
     /**
@@ -85,13 +136,7 @@ public class GibsonLanniPSFTest {
      */
     @Test
     public void testGetRadius() {
-    }
-
-    /**
-     * Test of computeDigitalPSF method, of class GibsonLanniPSF.
-     */
-    @Test
-    public void testComputeDigitalPSF() {
+        assertEquals(this.psf.getRadius(), 24.6, 0.1);
     }
     
 }

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+/**
+ *  Tests for the GibsonLanniPSF class.
+ * 
+ * @author Kyle M. Douglass
+ */
+public class GibsonLanniPSFTest {
+    private GibsonLanniPSF psf = null;
+    
+    public GibsonLanniPSFTest() {
+    }
+    
+    @Before
+    public void setUp() {
+        GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
+        
+        // Build the PSF
+        int numBasis = 100;
+        int numSamples = 1000;
+        int oversampling = 2;
+        int sizeX = 256;
+        int sizeY = 256;
+        double NA = 1.4;
+        double wavelength = 0.610;
+        double ns  = 1.33;
+        double ng0 = 1.5;
+        double ng  = 1.5;
+        double ni0 = 1.5;
+        double ni  = 1.5;
+        double ti0 = 150;
+        double tg0 = 170;
+        double tg  = 170;
+        double resLateral = 0.1;
+        double resPSF = 0.02;
+        double pZ = 2;
+        double stageDisplacement = -2;
+                
+        builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
+                .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
+                .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
+                .resLateral(resLateral).oversampling(oversampling)
+                .resPSF(resPSF).stageDisplacement(stageDisplacement).pZ(pZ);
+		
+        this.psf = builder.build();
+    }
+
+    /**
+     * Test of generatePixelSignature method, of class GibsonLanniPSF.
+     */
+    @Test
+    public void testGeneratePixelSignature() {
+    }
+
+    /**
+     * Test of generateSignature method, of class GibsonLanniPSF.
+     */
+    @Test
+    public void testGenerateSignature() {
+    }
+
+    /**
+     * Test of getRadius method, of class GibsonLanniPSF.
+     */
+    @Test
+    public void testGetRadius() {
+    }
+
+    /**
+     * Test of computeDigitalPSF method, of class GibsonLanniPSF.
+     */
+    @Test
+    public void testComputeDigitalPSF() {
+    }
+    
+}

--- a/test/resources/GibsonLanniAlgorithm.ipynb
+++ b/test/resources/GibsonLanniAlgorithm.ipynb
@@ -1,0 +1,620 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate test data for SASS implementation of the Gibson-Lanni PSF.\n",
+    "\n",
+    "This Python algorithm has been verified against the original MATLAB code from the paper Li, J., Xue, F., & Blu, T. (2017). Fast and accurate three-dimensional point spread function computation for fluorescence microscopy. JOSA A, 34(6), 1029-1034."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n",
+      "Python 3.5.2 |Anaconda 2.5.0 (64-bit)| (default, Jul  2 2016, 17:53:06) \n",
+      "[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]\n",
+      "\n",
+      "NumPy\t\t1.13.1\n",
+      "matplotlib\t2.0.2\n",
+      "SciPy\t\t0.19.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "%pylab inline\n",
+    "import scipy.special\n",
+    "from scipy.interpolate import interp1d\n",
+    "from scipy.interpolate import RectBivariateSpline\n",
+    "\n",
+    "print('Python {}\\n'.format(sys.version))\n",
+    "print('NumPy\\t\\t{}'.format(np.__version__))\n",
+    "print('matplotlib\\t{}'.format(matplotlib.__version__))\n",
+    "print('SciPy\\t\\t{}'.format(scipy.__version__))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simulation setup\n",
+    "## Define the simulation parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Image properties\n",
+    "# Size of the PSF array, pixels\n",
+    "size_x = 256\n",
+    "size_y = 256\n",
+    "size_z = 1\n",
+    "\n",
+    "# Precision control\n",
+    "num_basis    = 100  # Number of rescaled Bessels that approximate the phase function\n",
+    "num_samples  = 1000 # Number of pupil samples along radial direction\n",
+    "oversampling = 2    # Defines the upsampling ratio on the image space grid for computations\n",
+    "\n",
+    "# Microscope parameters\n",
+    "NA          = 1.4\n",
+    "wavelength  = 0.610 # microns\n",
+    "M           = 100   # magnification\n",
+    "ns          = 1.33  # specimen refractive index (RI)\n",
+    "ng0         = 1.5   # coverslip RI design value\n",
+    "ng          = 1.5   # coverslip RI experimental value\n",
+    "ni0         = 1.5   # immersion medium RI design value\n",
+    "ni          = 1.5   # immersion medium RI experimental value\n",
+    "ti0         = 150   # microns, working distance (immersion medium thickness) design value\n",
+    "tg0         = 170   # microns, coverslip thickness design value\n",
+    "tg          = 170   # microns, coverslip thickness experimental value\n",
+    "resPSF      = 0.02  # microns (resPSF in the Java code)\n",
+    "resLateral  = 0.1   # microns (resLateral in the Java code)\n",
+    "res_axial   = 0.25  # microns\n",
+    "pZ          = 2     # microns, particle distance from coverslip\n",
+    "z           = [-2]  # microns, stage displacement away from best focus\n",
+    "\n",
+    "# Scaling factors for the Fourier-Bessel series expansion\n",
+    "min_wavelength = 0.436 # microns\n",
+    "scaling_factor = NA * (3 * np.arange(1, num_basis + 1) - 2) * min_wavelength / wavelength"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the coordinate systems"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Place the origin at the center of the final PSF array\n",
+    "x0 = (size_x - 1) / 2\n",
+    "y0 = (size_y - 1) / 2\n",
+    "\n",
+    "# Find the maximum possible radius coordinate of the PSF array by finding the distance\n",
+    "# from the center of the array to a corner\n",
+    "max_radius = round(sqrt((size_x - x0) * (size_x - x0) + (size_y - y0) * (size_y - y0))) + 1;\n",
+    "\n",
+    "# Radial coordinates, image space\n",
+    "r = resPSF * np.arange(0, oversampling * max_radius) / oversampling\n",
+    "\n",
+    "# Radial coordinates, pupil space\n",
+    "a = min([NA, ns, ni, ni0, ng, ng0]) / NA\n",
+    "rho = np.linspace(0, a, num_samples)\n",
+    "\n",
+    "# Convert z to array\n",
+    "z = np.array(z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 1: Approximate the pupil phase with a Fourier-Bessel series\n",
+    "\n",
+    "`z.reshape(-1,1)` flips `z` from a row array to a column array so that it may be broadcast across `rho`.\n",
+    "\n",
+    "The coefficients `C` are found by a least-squares solution to the equation\n",
+    "\n",
+    "\\begin{equation*}\n",
+    "\\mathbf{\\phi} \\left( \\rho , z \\right)= \\mathbf{J} \\left( \\rho \\right) \\mathbf{c} \\left( z \\right)\n",
+    "\\end{equation*}\n",
+    "\n",
+    "\\\\( \\mathbf{c} \\\\) has dimensions `num_basis` \\\\( \\times \\\\) `len(z)`. The `J` array has dimensions `num_basis` \\\\( \\times \\\\) `len(rho)` and the `phase` array has dimensions `len(z)` \\\\( \\times \\\\) `len(rho)`. The `J` and `phase` arrays are therefore transposed to get the dimensions right in the call to `np.linalg.lstsq`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Define the wavefront aberration\n",
+    "OPDs = pZ * np.sqrt(ns * ns - NA * NA * rho * rho) # OPD in the sample\n",
+    "OPDi = (z.reshape(-1,1) + ti0) * np.sqrt(ni * ni - NA * NA * rho * rho) - ti0 * np.sqrt(ni0 * ni0 - NA * NA * rho * rho) # OPD in the immersion medium\n",
+    "OPDg = tg * np.sqrt(ng * ng - NA * NA * rho * rho) - tg0 * np.sqrt(ng0 * ng0 - NA * NA * rho * rho) # OPD in the coverslip\n",
+    "W    = 2 * np.pi / wavelength * (OPDs + OPDi + OPDg)\n",
+    "\n",
+    "# Sample the phase\n",
+    "# Shape is (number of z samples by number of rho samples)\n",
+    "phase = np.cos(W) + 1j * np.sin(W)\n",
+    "\n",
+    "# Define the basis of Bessel functions\n",
+    "# Shape is (number of basis functions by number of rho samples)\n",
+    "J = scipy.special.jv(0, scaling_factor.reshape(-1, 1) * rho)\n",
+    "\n",
+    "# Compute the approximation to the sampled pupil phase by finding the least squares\n",
+    "# solution to the complex coefficients of the Fourier-Bessel expansion.\n",
+    "# Shape of C is (number of basis functions by number of z samples).\n",
+    "# Note the matrix transposes to get the dimensions correct.\n",
+    "C, residuals, _, _ = np.linalg.lstsq(J.T, phase.T)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 2: Compute the PSF\n",
+    "\n",
+    "Here, we use the Fourier-Bessel series expansion of the phase function and a Bessel integral identity to compute the approximate PSF. Each coefficient \\\\( c_{m} \\left( z \\right) \\\\) needs to be multiplied by\n",
+    "\n",
+    "\\begin{equation*}\n",
+    "R \\left(r; \\mathbf{p} \\right) = \\frac{\\sigma_m J_1 \\left( \\sigma_m a \\right) J_0 \\left( \\beta a \\right)a - \\beta J_0 \\left( \\sigma_m a \\right) J_1 \\left( \\beta a \\right)a }{\\sigma_m^2 - \\beta^2}\n",
+    "\\end{equation*}\n",
+    "\n",
+    "and the resulting products summed over the number of basis functions. \\\\( \\mathbf{p} \\\\) is the parameter vector for the Gibson-Lanni model, \\\\( \\sigma_m \\\\) is the scaling factor for the argument to the \\\\( m'th \\\\) Bessel basis function, and \\\\( \\beta = kr\\text{NA} \\\\).\n",
+    "\n",
+    "`b` is defined such that `R` has dimensions of `len(r)` \\\\( \\times \\\\) `len(rho)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "b = 2 * np. pi * r.reshape(-1, 1) * NA / wavelength\n",
+    "\n",
+    "# Convenience functions for J0 and J1 Bessel functions\n",
+    "J0 = lambda x: scipy.special.jv(0, x)\n",
+    "J1 = lambda x: scipy.special.jv(1, x)\n",
+    "\n",
+    "# See equation 5 in Li, Xue, and Blu\n",
+    "denom = scaling_factor * scaling_factor - b * b\n",
+    "R = (scaling_factor * J1(scaling_factor * a) * J0(b * a) * a - b * J0(scaling_factor * a) * J1(b * a) * a)\n",
+    "R /= denom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now compute the point-spread function via\n",
+    "\n",
+    "\\begin{equation*}\n",
+    "PSF \\left( r, z; z_p, \\mathbf{p} \\right) = \\left| \\mathbf{R} \\left( r; \\mathbf{p} \\right) \\mathbf{c} \\left( z \\right) \\right|^2\n",
+    "\\end{equation*}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# The transpose places the axial direction along the first dimension of the array, i.e. rows\n",
+    "# This is only for convenience.\n",
+    "PSF_rz = (np.abs(R.dot(C))**2).T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 3: Resample the PSF onto a rotationally-symmetric Cartesian grid\n",
+    "\n",
+    "Here we generate a two dimensional grid where the value at each grid point is the distance of the point from the center of the grid. These values are supplied to an interpolation function computed from `PSF_rz` to produce a rotationally-symmetric 2D PSF at each z-position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create the fleshed-out xy grid of radial distances from the center\n",
+    "xy      = np.mgrid[0:size_y, 0:size_x]\n",
+    "r_pixel = np.sqrt((xy[1] - x0) * (xy[1] - x0) + (xy[0] - y0) * (xy[0] - y0)) * resPSF\n",
+    "\n",
+    "PSF = np.zeros((size_y, size_x, size_z))\n",
+    "\n",
+    "for z_index in range(PSF.shape[2]):\n",
+    "    # Interpolate the radial PSF function\n",
+    "    PSF_interp = interp1d(r, PSF_rz[z_index, :])\n",
+    "    \n",
+    "    # Evaluate the PSF at each value of r_pixel\n",
+    "    PSF[:,:, z_index] = PSF_interp(r_pixel.ravel()).reshape(size_y, size_x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Normalize to the area\n",
+    "norm_const = np.sum(np.sum(PSF[:,:,0])) * resPSF**2\n",
+    "PSF /= norm_const"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHWtJREFUeJztnUusJNd5339fVd97Z4ZDMnzYY3pIRBRAG6AWoY0BFcCC\noYCIJQsBKG+E0cLgQsB4wRg24Cwoe2FtBDiBH5vABmiYMBM4YgjbgojASEASBoRsLI0UWiKp0BpL\nlMkByQkpiw/N43ZXfVmcU93VVdXvqn7c+/8Bhe5bXY+vC/f86/9959Rpc3eEEKJMsukAhBDbh4RB\nCFFDwiCEqCFhEELUkDAIIWpIGIQQNToTBjP7pJm9YmaXzOyxrs4jhGgf62Icg5mlwD8A/xZ4Hfg6\n8Fl3f7n1kwkhWqcrx/AgcMndv+fuh8BTwMMdnUsI0TK9jo57Fnit9PfrwEcnbbxvB36CmzoKRQgB\n8D7//La7/8Q823YlDDMxswvABYATnOKj9tCmQhHiWPCc/+UP5t22q1TiMnBP6e+747oh7v64u59z\n93N7HHQUhhBiGboShq8D95nZvWa2D5wHnunoXEKIlukklXD3gZn9e+B/ASnwhLu/1MW5hBDt01mN\nwd3/Bvibro4vhOgOjXwUQtSQMAghakgYhBA1JAxCiBoSBiFEDQmDEKKGhEEIUUPCIISoIWEQQtSQ\nMAghakgYhBA1JAxCiBoSBiFEDQmDEKKGhEEIUUPCIISoIWEQQtSQMAghakgYhBA1JAxCiBoSBiFE\nDQmDEKKGhEEIUUPCIISoIWEQQtSQMAghakgYhBA1JAxCiBoSBiFEDQmDEKKGhEEIUUPCIISoIWEQ\nQtSQMAghavRW2dnMXgXeBzJg4O7nzOx24L8DHwJeBT7j7v+8WphCiHXShmP4N+7+gLufi38/Bjzv\n7vcBz8e/hRA7RBepxMPAk/H9k8CnOziHEKJDVhUGB54zs2+Y2YW47oy7vxHfvwmcadrRzC6Y2UUz\nu9jnxophCCHaZKUaA/Axd79sZj8JPGtm/7f8obu7mXnTju7+OPA4wC12e+M2QojNsJJjcPfL8fUK\n8GXgQeAtM7sLIL5eWTVIIcR6WVoYzOwmM7u5eA/8EvAi8AzwSNzsEeArqwYphFgvq6QSZ4Avm1lx\nnP/m7v/TzL4OPG1mnwN+AHxm9TCFEOtkaWFw9+8B/6ph/TvAQ6sEJYTYLBr5KISosWqvhDiKhPRw\ndVydTbuKhOG405YIzHtsicVOIGE4rnQpCPOcVwKx1UgYjgubEoJJVOORUGwVEoajyrYJwSwkFFuF\nhOGosWuCMAmlHBtF3ZVHiaMiCmWO4nfaAeQYjgJHvfHIPawdCcMuc9QFoYoEYm0oldhVjpsolDnO\n331NyDHsGmoUAbmHTpFj2CUkCnV0TTpBjmEX0D//dOQeWkeOQQhRQ45h29m0W7AF7x2edxPHPJjJ\nNbSEhGGbWbcoLCoC8x5jnWIhcWgFCcM2sg5BaEMEVjlXl2KhmsPKSBi2ja5FYZ2CMI0ijq4FQuKw\nFBKGbaLTSVO2RBCqdC0QEoel2NL/FtEq2yoKZXYhxmOEHMO20IVbaLmxWdIco+ct3ZG7cg9yDQsj\nYdgG2haFFQVhkgAsuv3SgtGFQEgcFkLCsEm2QBAWFYFVj72QWLQtEOqtmBsJw1FhQVHoUhDmOe/C\nArHJgVPHEFV8NkWbbmEBUbDENiYKK8XRZr1k06NJdwA5hk2wAVFYSgyWbYwL3N0XchBtOgfVHKYi\nYdhluujia3tYdOs9DEor1oGEYd205RbmaMBzuYR5hGBet9F0168ef0KjLsc60z20JQ5yDRORMKyT\nNYnCyoKwbA2iut80oZjSsOdKLyQOnaLi466xqihYMvkYic0lCmaGzSNy0443LY7hJnN8F9EJcgzr\nog23sEpDmCYGk3aZEfOkz716By6fo+oCVh2r0IZzkGuoIcndFdqqKZRp2L5wA3M5gklxTDtGS6Mq\nKxstdEwxm5lX1MyeMLMrZvZiad3tZvasmX03vt5W+uzzZnbJzF4xs090FfhOsapbWFUUmvavbN/Y\nkJNkuWXmcRtinfId1yIOGtswxjxX88+BT1bWPQY87+73Ac/HvzGz+4HzwEfiPn9sZmlr0e4iHf/D\nTRwoVOTw5QZT5Pxx+9qdvdrAzZZbGoSifq7xWCbGPOt7tonEYchMYXD3rwI/rKx+GHgyvn8S+HRp\n/VPufsPdvw9cAh5sKdbjyTJ30jkdwuizyp2+aOBj+8/vEmr7V7ZZxUEs7IzEUix7Jc+4+xvx/ZvA\nmfj+LPBaabvX47rjySbuQDNEoWbtJwnCjLv+TLdRPV7lXPU4FksvRLes3Cvh7m5mC5d0zewCcAHg\nBKdWDeNosmreDTVRGK2vCELD+rnu7IBVOgXcfXScPB8dv7o+nmPYi5FY89iH6vkSmzzGQSMjW2FZ\nSX7LzO4CiK9X4vrLwD2l7e6O62q4++Pufs7dz+1xsGQYYiqLiEKDMxirAyQ2XgMoL5XtGp1E+VyV\nGGY6B7F2lhWGZ4BH4vtHgK+U1p83swMzuxe4D/jaaiEeU5ax0dVCYxNVUZgmCOXGn6Z1oSiWNG0U\nikaBmCRQYzFWCpKrXIeF95UwwRyphJl9Cfg4cKeZvQ78LvB7wNNm9jngB8BnANz9JTN7GngZGACP\nunvWUezbzSr/YIumENXtm5zChLv2WC9BcZykVBuYR2xyH91iPAeSkDbEDNM8H6YIniTDNKIcl8V1\njWlFwyComcOmV0kpNOBptjC4+2cnfPTQhO2/CHxxlaDECkxKH8KK0nbJyB3A6E4PkKRjxxoeZ5LY\nRQEIjToNDdoA4j0hTyCJNYW8Ig6VRrhMzUG0j4ZEbxuruoViddWyV5yDVR1B4RKiQIyJQZPbKBMb\nsuV5eJ/aSCQ8D24iL+LMQuOvFidLYjEmDtXvWnEBKkR2g4ThqNOQx9cGGYWVI1Eo9ikLStldVMk9\nCkIaXvM8NG7yKAh5KdUILqCx8VfTDLExJAxdsGx9oaXaQq2uMPy8oaZQEoThvuVRj2P1hoaBT6Va\nQhAFH6YH5o4nMEwvPI/nykfi0FRzKITFvZ5OrMs1HPM6g4ThqFAVhTKxsddEofRqteHMNhICM7z8\ndxkPbsEK12A+EghG6YUX6UTio5pDVRwqDXGiOIjOkTC0TQfdXTPdQtPn5bpAudBo5UafYGnsiiwa\nfZrgvXQkEmlwD56Gv73y/SymDmRRELJ82MhtkIW/o3sgy3CIFUiLIpKPFySLQVDVlKLaS7GIa1iW\nY+waJAxHkVnFQhgJREUUghikQSCSJBQSi9deszDYIMczD+4gScJrNuqiJIuNeFiDSGBSL3bRGFVv\n2CgShiNE8/wH5V6Hklsopw8lUfA0gV4aRCBJoJeQ9xI8NXwvCkNxGo/C0M+xzEkGOQxyyMOxPc+H\nmxbiEFIHgmMYphfRcTSIwcQeCtEpEoZtYdnRetU0osEtmNVTiOE2TaKwF4Qhj6/eM/K9hHwv1Bq8\n2D0Hy52kn5D0c3yQYIOcpJ+BGZbnOIyLQ+EIrNRbkSeY+UgAJrmGZWsN6rZcGAnDLtI0X8E0t1Dd\nt3ALRQ2hLAppSr4fxCHfT8j2gzBk+wnZgZGnjDmGJIP0hpMeGjYIr6HLMyMZBMcwJg55MuqtaEop\n5nUNauydImFok3UVHgsmzsdQcQvD5xrS0TiFuHgvDbl/rxCDlMHN+2QnEgYnEwYnjMGBkZ0wBjdB\nnjLmGJIMej+G9HpC74bTu+70ruWk11N6QHKYYEmCDzLIMqxIKfI8jHMgBTJwC0XIqmto+s4TXIMK\nkO0hYTiqNE2eQmV4czJKJULKkOB7KdmJhP6pIAz9U5CdNAYnoH+Lk/cIXY4AuZEMIE+N3r6RXyOk\nGvEU6fU0NNSiVyLPwzl9FIvjdUFV4XHjSBh2jWlpROXpxbEuSig9C1EewBSKjJ6EmkK+H53CyYT+\nTdA/bQxOweCUM/gXA9hzLI0PPGUJWd/wpEd+1ej1YhckCebQu5pAnpJkDokHp1IeL5FlIaaM4cCn\nmmuoDniqXgulE50gYdgG1jFTUbXgWHILpAbRMWT7IX3onwqi0D8Ng9M52emMk3dc42BvQC8KwyBL\nuNHvcY2TeC+Nzz/EUY95qEvYwKEXHUCejM7tVi9Edv39JSJzI2HYVZaY0GRYcAx/lEY1xi7JnuG9\nWFM4GZ3C6Zzsloz9W25w9rZ3uXX/GvtJKBge5invHp7kn7KEwyRMtmN5QjIwBn2Gx8t7CckgwSwf\nHz2ZxEIkC+bwGgnZORKGo0jtGYmKiMSG6Ukc0ZiG13wvOIbsRKgpDE452ekgCnfe+gE/e8sV7tj/\ngFPJIQBX833eOTzN1f4ebwOH+QE2MJLDsGT7CUk/jHMozkESioy1ol6RUpS/g+oMG0PCsMWsMl16\nY32hmkYUNYZegsdxCtlB6H3o3xJqCifvuMbZ297lZ2+5wr+77QV+Kn2Pm5M+AO/ne7yZ3QLAK3s/\nyeX0Vq5xEst7JFk4VnpoJHtJHONQeTjLS+9zmusMS1yz1nsmjiEShuNKkUaUlySMU8hTQu/DnnOw\nN+DW/Wvcsf8BP5W+x5m0z81J+Lc5ZX3gPe7Y/4Bb92/m7b2buLYXei6K44ReitFi5VRCbC0Shh1n\nlZ+SGz9QHJ9QvCah96GX5uwnGaeSQ25OgiicTk7Ena5z1fucSg7ZTzJ6aR56LBKPT2OOjtlKiBoe\nvTbWUA4XQuwacgw7jru34xo8jGQcvuaGZwmDLOEwT7ma7/N+vhfTh+sAvJ8PeD/f42q+z2GeMsgS\nPEvCQ1T5+DHbQG5hfUgYjis+GpE4XHInycIw52QAWd+40e/x7uFJ3jk8HQuN73HVx4uP7xye5t3D\nk9zo96AfRkMWx7F8/BzFecV2I2HYYjz3pXsm3D3crZP4PEJemV1p+D7HBjnWz0n6CekNp/fjMMzZ\nkzB46Z+yhKv9PYDG7sr/885Z3n73NIc/OqD3ox5771l4fuKGD7srbTCawGUYQ/l9+MKQ+0rOQD0S\n7SBhOIrECVNGf/t4NWk4q7ND5mGSlcxJ+jnpoYUHovaN/KrhvZTD5IC3CV2St+7fXBvg9Pa7pzl8\n74D0g5TeVaN3HdLrTnqYk8S5GojnsKEIVBpwtUFrDMNGkTDsKrkvPPoxuIh8NJPScL7GnGRQzKfg\n9G44+TXo9UbTvB/mB1xOb+XtvZtqQ6IPfxRF4YOE3lVIr4Vj2CAsySAfTS1fTiXyfDl3IFfQORKG\nbaCYPbnrc5CO23eLczQmCQyC3U8Pjd71orsxzKRgeYINjGuc5FrlISr6Ru9HveAUrsLeB87eVehF\nx2DFrE6ZD+d/HEsjhrF1jJ6TWAgJw67RICLDnokihSiGPI/VGZLQIFMb/chLUWPIw3RsST887di7\nlscnoxNwJ4nDnC3vNT52vfdeTB+uRVG4ltO7lpMchtmcbHiOco0hNtRp9YXSdo3OQo29MyQMR5Vq\nncE9PvgYRaR8587y4YhESzLS6+En6szB8vBAVHJoJJkNRzNCdaIWr0zUkmP9LBQ2B3ndLVBq7LV6\ngxr8ppEwtIk3TDqy6iGn9UxMqjOU4hi6BnPCU0opTh66DiFM8Z57mLg11hp6hElWelcXmdotj1O7\nBadg/Yzkah/LMhjEmZsK15BlQRRyhzyLrw1uYdJ3nnKtWueYdq1KGHaRaelEmaprKPbNEzxhNM07\njM3NmBwmoZHlKTZwvGck/TCfY/NksKFHIxQbY/owyOuiEF+HotCUCjS4BaUR60fCsC0sW4CsuoZC\nDKquIQpC6LasFCKr4hD3TzIfTh9v/Tw8JTnH9PGWF0XHiihUC44lgWh0C1WRWNYRSEQWRsJwhJjq\nGnKPPwsXxSEPMzUXKcWYOAyysD4Jxb9kEH9wZjD5B2cofnBm+Jo3ioKX6wyFa8gnCAEaBr0pJAxH\nkQbXUKNwEFkWxjXA6Bejsiz0ViRJ/M2HHE8NmyAM5HEQU+Un6mpOIcsmpxDDuCaLhFgfEoa2WVcB\nspx6NBUhy+KQ53iShCJknKo9TIoSJ1UrnIZZEIIsr/2obfF3zZEMB0mVxiYMC4sjkagVG0tOwQsR\nmSYK5TSiQVhUeGwXCcNRIYpDYzpRFgez8bTCRsXI4TTvwNjsSlaajm2CMIzO42MOYZgKlMVgmiiM\nHbq0r1grM6tdZvaEmV0xsxdL675gZpfN7IW4fKr02efN7JKZvWJmn+gq8K1m2TvNFIvdeEesbl9u\nbNBQvMvrDdXjXTza/GFDjekEWSgiDlOELBtfJm1T7n3IsnAOnyAKlRjHv0Pley/qFpYtPB5jtwDz\nOYY/B/4z8F8q6//I3X+/vMLM7gfOAx8Bfhp4zsx+xn3STxuLzmnoshyNlPQ4voFRb0WehHEOZqFB\nFzNLuzP8JZkqZSEqD14aE5/xht5YVFRdYWuY6Rjc/avAD+c83sPAU+5+w92/D1wCHlwhvuPHqq6h\nWF1ueNX8vewcPC9Z/FENwLOwjTe5hAmLx+N6lo/qCWMCUXIDRf0hrBgThYk9EetyC2Klqd1+3cy+\nFVON2+K6s8BrpW1ej+tqmNkFM7toZhf73FghDDFGqaHUGlhFLEYFwZLFHzbofJReZHlY8glL/HyY\nNng+NqKxfOxa+lCJcVzQjred3yTLCsOfAB8GHgDeAP5g0QO4++Pufs7dz+1xsGQYW8wqOeoM11C7\nS5buxkBNHMbu0GM9B/nwc88qzmAwiLWDQVjybPS+upQ/K/YpO4ksH4+jEkM5jqbvUPt+k67DnNdw\nJse8vgBL9kq4+1vFezP7U+B/xD8vA/eUNr07rhOLssxIyFldmDBecyjfvZNk2DCtaFNJqXEVvy85\n6bxj52ioI5TThuq6WozTuyZnIlFYmaUcg5ndVfrzV4Cix+IZ4LyZHZjZvcB9wNdWC1EszaS0osnK\nl3L+0d29shR37upS2W7s7l+tJTTEoPRh+5jpGMzsS8DHgTvN7HXgd4GPm9kDgAOvAr8G4O4vmdnT\nwMvAAHhUPRIrMMU1zD0fZMk5jI1xKDmFYYMt5nSI66s1CptwI57ZwzDFJSwjCio4do9tw1j0W+x2\n/6g9tOkwumHVUZBT0omJwtC0T2XbsUFQ1Scwm2KublOlKS2o/m9N63lYpMelS2HYgvbQFc/5X37D\n3c/Ns61GPm47y7iGpn0qNYeJ7iF8GF7LArHIGIMpglCcuxZb7RgbEAUxRMLQNR08OzF2+NhQGp+l\nKCgXJAuS8Z97s3IaMdxmyU6reZ6SXEAMwkdruJMfYbewKBKGdbCqOMzRQzG15jCng4BKitHCSMTm\n+kMHoqAUolX025W7whz/+AvfVRu2H45rWKGhTD3GgjGuRRREDTmGddFGSrHKNPNF42lyDgUVxzFJ\nHApXMbd4dFosbEEU5BZqSBh2jRniMLMbc5JAwKgBz+gGXZcgzHQLcgqdIWFYJ20VIucQB5jSnVkc\nI2xU/6zaIOf9xauWbP9a0we5hUYkDOtmTeIQNin1OkwrTJaZRygWYc4GvFB9RKLQORKGXaaLn7Zr\n6uZc5Rhto/RhLUgYNkGbYxvmFIe50oumY3fMRpwCyC3MQN2Vm6LNf8wFGszMx5XXxMJxSBTWihzD\nUWHBtGIpB9ECS4mS0oe1I2HYJE3PJKx0vCk9DRN3qTfUtsRiZWfStiDIKcyNhGEbaPt5iiUEYnz3\nCQObJghG66lJFw5BorAQEoZtoYuHrVYUiPrhOm5cXaUMEoWFUfHxOLALOfouxHiMkGPYJrp8RLtl\n99AaXQuC3MJSSBi2jY7nb9gagViHQ5AoLI2EYRtpu7ei8RwNDbMrsVh3miBBWBkJwzbTtXuona8F\nsdh0rUCi0AoShm1n3eJQO/8OFQUlCq2xZZUoIcQ2IMewC6yj5rDLyCm0jhzDLqEGUEfXpBPkGHYN\nuYeABKFT5Bh2lePcMI7zd18Tcgy7zHFzDxKEtSFhOAocdYGQIKwdpRJHiaPYgI7id9oB5BiOGk0N\naVechERga5BjOA7sQoPbhRiPEXIMx4Vqw9u0i5AQbDUShuPKpgqWEoSdYGYqYWb3mNnfmtnLZvaS\nmf1GXH+7mT1rZt+Nr7eV9vm8mV0ys1fM7BNdfgGxIu71ZReOLTplnhrDAPgtd78f+NfAo2Z2P/AY\n8Ly73wc8H/8mfnYe+AjwSeCPzSztInjREU0NeplF7CwzhcHd33D3b8b37wPfAc4CDwNPxs2eBD4d\n3z8MPOXuN9z9+8Al4MG2AxdCdMdCvRJm9iHg54C/A864+xvxozeBM/H9WeC10m6vx3VCiB1hbmEw\ns9PAXwG/6e7vlT9zdwcW8o5mdsHMLprZxT43FtlVCNExcwmDme0RROEv3P2v4+q3zOyu+PldwJW4\n/jJwT2n3u+O6Mdz9cXc/5+7n9jhYNn4hRAfM0ythwJ8B33H3Pyx99AzwSHz/CPCV0vrzZnZgZvcC\n9wFfay9kIUTXzDOO4ReAXwW+bWYvxHW/Dfwe8LSZfQ74AfAZAHd/ycyeBl4m9Gg86u5Z65ELITpj\npjC4+/8GJo2CeWjCPl8EvrhCXEKIDaJnJYQQNSQMQogaEgYhRA0JgxCihoRBCFFDwiCEqCFhEELU\nkDAIIWpIGIQQNSQMQogaEgYhRA0JgxCihoRBCFFDwiCEqCFhEELUkDAIIWpIGIQQNSQMQogaEgYh\nRA0JgxCihoRBCFFDwiCEqCFhEELUkDAIIWpIGIQQNSQMQogaEgYhRA0JgxCihoRBCFFDwiCEqCFh\nEELUkDAIIWpIGIQQNSQMQogaM4XBzO4xs781s5fN7CUz+424/gtmdtnMXojLp0r7fN7MLpnZK2b2\niS6/gBCifXpzbDMAfsvdv2lmNwPfMLNn42d/5O6/X97YzO4HzgMfAX4aeM7MfsbdszYDF0J0x0zH\n4O5vuPs34/v3ge8AZ6fs8jDwlLvfcPfvA5eAB9sIVgixHhaqMZjZh4CfA/4urvp1M/uWmT1hZrfF\ndWeB10q7vU6DkJjZBTO7aGYX+9xYOHAhRHfMLQxmdhr4K+A33f094E+ADwMPAG8Af7DIid39cXc/\n5+7n9jhYZFchRMfMJQxmtkcQhb9w978GcPe33D1z9xz4U0bpwmXgntLud8d1QogdYZ5eCQP+DPiO\nu/9haf1dpc1+BXgxvn8GOG9mB2Z2L3Af8LX2QhZCdM08vRK/APwq8G0zeyGu+23gs2b2AODAq8Cv\nAbj7S2b2NPAyoUfjUfVICLFbmLtvOgbM7P8BPwbe3nQsc3AnuxEn7E6suxIn7E6sTXH+S3f/iXl2\n3gphADCzi+5+btNxzGJX4oTdiXVX4oTdiXXVODUkWghRQ8IghKixTcLw+KYDmJNdiRN2J9ZdiRN2\nJ9aV4tyaGoMQYnvYJscghNgSNi4MZvbJ+Hj2JTN7bNPxVDGzV83s2/HR8otx3e1m9qyZfTe+3jbr\nOB3E9YSZXTGzF0vrJsa1yUfhJ8S6dY/tT5liYKuu61qmQnD3jS1ACvwj4ZmLfeDvgfs3GVNDjK8C\nd1bW/Sfgsfj+MeA/biCuXwR+HnhxVlzA/fHaHgD3xmuebjjWLwD/oWHbjcUK3AX8fHx/M/APMZ6t\nuq5T4mztmm7aMTwIXHL377n7IfAU4bHtbedh4Mn4/kng0+sOwN2/CvywsnpSXBt9FH5CrJPYWKw+\neYqBrbquU+KcxMJxbloY5npEe8M4YbKZb5jZhbjujLu/Ed+/CZzZTGg1JsW1rdd56cf2u6YyxcDW\nXtc2p0Ios2lh2AU+5u4PAL8MPGpmv1j+0INX27qunW2Nq8RKj+13ScMUA0O26bq2PRVCmU0Lw9Y/\nou3ul+PrFeDLBAv2VvF0aXy9srkIx5gU19ZdZ9/Sx/abphhgC69r11MhbFoYvg7cZ2b3mtk+Ya7I\nZzYc0xAzuynOc4mZ3QT8EuHx8meAR+JmjwBf2UyENSbFtXWPwm/jY/uTphhgy67rWqZCWEe1d0aF\n9VOEquo/Ar+z6XgqsX2YUM39e+ClIj7gDuB54LvAc8DtG4jtSwS72CfkjJ+bFhfwO/EavwL88hbE\n+l+BbwPfiv+4d206VuBjhDThW8ALcfnUtl3XKXG2dk018lEIUWPTqYQQYguRMAghakgYhBA1JAxC\niBoSBiFEDQmDEKKGhEEIUUPCIISo8f8B9jGxQurzXmoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f2447d5b0b8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(PSF[:,:,0])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Compute the cumulative distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min: 0.0000\n",
+      "Max: 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "cdf = np.cumsum(PSF[:,:,0], axis=1) * resPSF\n",
+    "cdf = np.cumsum(cdf, axis=0) * resPSF\n",
+    "print('Min: {:.4f}'.format(np.min(cdf)))\n",
+    "print('Max: {:.4f}'.format(np.max(cdf)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnV3INdd13/9rzvO8UuXYYNWpeC2JSgH5Qi5UCUIpxAQX\n09gxBTk3Rr5IBRV9c6GmCbgQ2bmIIQjckjg3oaFvsIhSYquiibEopkESKaaQxFaMY0tyFb+xZSzx\nWkpaQ0wvFOs5qxfzcfbs2d8f83HO+sPhnDOzZ89+5pn1O2uvvfYeYmaIRCKRqmbpBohEovVJwCAS\niSYSMIhEookEDCKRaCIBg0gkmkjAIBKJJqoGBiL6ABG9RETXiOiRWucRiUTlRTXyGIhoB+CvAPwL\nAK8A+DKAjzDzi8VPJhKJiquWx3AfgGvM/C1m/nsATwC4v9K5RCJRYZ1VqvdWAN9Vvr8C4CdthS/R\nDXwj3lKpKSKRCAB+gO//LTP/aEjZWmDwioiuALgCADfiJvwkvW+ppohEJ6Fn+L99J7Rsra7EqwBu\nV77f1m0bxMxXmfleZr73HDdUaoZIJEpRLTB8GcBdRHQnEV0C8ACApyqdSyQSFVaVrgQzv0lE/xbA\nHwPYAXiMmV+ocS6RSFRe1WIMzPwFAF+oVb9IJKonyXwUiUQTCRhEItFEAgaRSDSRgEEkEk0kYBCJ\nRBMJGEQi0USLpUSLRCKPiMrWFzGRWsAgEpVSaUNeUAIG0WnoiIx2DgkYRNuXGH1xCRhE65cY/uwS\nMIjWIwHAaiRgEM0vAcDqJWAQ1ZVAYJMSMIjyJIZ/lBIwiOIkIFinqGwSs4BB5JfAoK4KG3UJCRhE\nUwkI0rVCI0+RgEHUSmDg1pEYfKgEDKcuAUKrEzN8nwQMp6JTAYAYeBEJGI5dxwwEgUA1CRiOVccG\nBIHArBIwHJuOBQgCgmRRY7kHLsLrEDAci7YOBAHBSFbjnkkChq1ri0A4QQgsbeixEjBsUVuBwREA\nYGsGXUoChi1pC0DYIAxO1fhdEjBsQWsHwkZgIAAIl4Bh7VorFFYMAwFAvgQMa9UagbBSGJwsCCr+\nPwQMa9LaYLACEGza6Fdw/VIlYFiL1gSFBW/oTYFgw4bvk4BhDVoLFBa60VcLgyM2fJ+ywEBELwP4\nAdpkyzeZ+V4iuhnAfwVwB4CXAXyYmb+f18wj1QkDYVUwOGEA2FTiivxzZr6Hme/tvj8C4FlmvgvA\ns913ka4ThAI1NLwWETXm17GqofEr5tAKzbkfwOPd58cBfKjCObatpaEwo1EsBoNjAYBu3DGvDOXG\nGBjAM0R0AeA/M/NVALcw8/Vu//cA3GI6kIiuALgCADfipsxmbERLAmEmCMymNRr6mrpHmcoFw3uY\n+VUi+kcAniai/63uZGYmIjYd2EHkKgC8jW42ljkqHTEUqgNhLRA4IsP3KQsMzPxq9/46EX0OwH0A\nXiOiy8x8nYguA3i9QDu3raWgUNGgjhYGJ2T8LiVffSJ6CxG9tf8M4GcAPA/gKQAPdsUeBPD53EZu\nVkTLQKFin7pavGCJeEDhfvkSIqLgV4xyPIZbAHyuO+EZgM8w8/8goi8DeJKIHgLwHQAfzjiHKFYV\ngVCp4jr1qtqIwccab00lg4GZvwXgnxq2/x8A78tp1FFoKU+heJWF/47aIFgZBNZk7DGSzMfSmvtG\nWDMMakFgZuPfqnHnSMBQUnPeQKcChJkgsCnjb+p3vwQMpbSlG0vT6oBQEQarBMAMhh4rAcPWVNhT\nKAKFEm2qBIPFQLBCY4+RgKGE5rr5CkJhFUAoDINZIbBxw/dJwJCjjQEhGwY57SgAgWqGvyYjX0lX\nR8Cwdq0BCqltWBsMlgLASow9RgKGVM3xz14aCgt4CMVAMBcENmj0IRIwpGgjUJgdCBkeQjYQaoJg\nrcZf8W8WMMSq9k2yJBBSz59wvtWBYEnjX1OMo5OAYU3ampcwJxBKGc9cAFihscdIwBCjmjdVJhRm\nAULkOaIhkGtMxxCoVLRkMpaAIVTHBoXYc0acYxYgbCxIucqMS4cEDCE6ZSjUAkKsQa4tJtFp9Qaf\n6EkKGJZUBhROAghLxyOwsOEvOIVcwOBTrRtj7qXLKkAh2GhqwyATBLMZ/8rWinBJwODSSqEQ7S2E\nnm8pIMwUpKwCgLUZe6EfHAGDTSuEQhUglIJBaQhEGn+W0W952bpKEjDMqbmgUHIWZojB+Yy4RB2T\nKlO6HAUBcOSrWAsYNqAqUPDUuSYgzA6BE1uX0iQBg0k1uhFrcitzoZALhNIwWGKSWKk2lFLhe1bA\nMIfW0oUIqMtpkJWBEB7UrBR8LXW+WK0wF0LAoKv0P2kOKBQIMmZ5CRkw8Z93hthK8SXyV2DomTAU\nMKhaCRRWAYQKIHB7IwF/c+Fh12n9RxCc7LXw065FhbVqKCRAJAsGBYdbu8aEl01pS46WjlFoEjD0\nWoG3UPSpT466kuIIkVCwQ8dx7pIgSPl/bmD5e5tKJ28JGGqo9q9LRpCxGBTmAkJQF6Ogl5XTjkit\neQKWgAFYRbCoWBciBQq1gGBrSw4IQv5XFaeUG0836xPIJMFpe6rZfVghECb1mtpga7cVGplxh5rr\nRhwOTDvOpxUsDtNLwLAFzQWFkkAAzO02wiOhm1F6wldIW0I0h3HP4DUIGEpd5KWCjbWgEAIE0/lz\nYZAIgiAALDClO+vcC55XwLCQinQhSkChlJeQA4TQY21tCTmHSUsuKVe7zkydNhgW+ocs4imEGoFW\nLimOMIFGIkRM53fVa1KtNSFyj/Np4bwG71UjoseI6HUiel7ZdjMRPU1E3+ze367s+xgRXSOil4jo\n/bUavirVGp5M6Z7E3Kie7kOQl9C3saHDS61frUMtbzmGiEavSV3qS2237WU71lZXSFnTcaa/Kedl\nUmzbfG11KMRj+D0Avw3g95VtjwB4lpk/SUSPdN9/hYjuBvAAgHcDeCeAZ4joXcx8EdWqObRQbCHI\nW0gMNgZ5CrGxhJGhOzwDn1egGb/hpNNtlvY5ywd5EZH/+9x7ZQ7PdO4EJ2b+IhHdoW2+H8B7u8+P\nA/ifAH6l2/4EM78B4NtEdA3AfQD+tExzV6atQ8FVhyuG4OoqOMpN2hgAqSQAlEyKSi1f+vgAccHu\nR2qM4RZmvt59/h6AW7rPtwL4M6XcK922dWmFwZ4glYaCUiYICglAiIZBqDdRJBEqo9sVqZJGa1XB\n+zo7+MjMTEQcexwRXQFwBQBuxE25zZhfc3sLOVAw1meBQkh7YoGgxwOc9UVAIDcwGWhIWUa9wW4E\nkA6G14joMjNfJ6LLAF7vtr8K4Hal3G3dtomY+SqAqwDwNro5GizJ2qK3kAsFx690UDyh314KCF4v\nwrM/dbuiYGNf22hF7bo7pYLhKQAPAvhk9/55ZftniOhTaIOPdwH4Um4jV6clYgt68dCbw/FrHQWF\n0YHT/UYg2GAQC4KIYKXX4FOuW6hKG+yCQ5ZeMBDRZ9EGGt9BRK8A+DW0QHiSiB4C8B0AHwYAZn6B\niJ4E8CKANwE8vKoRiRL/uJV0IablwkcfvEAwjTZo+5wgGI6xnSfgc6eJoZf2Hmp7DqWOt4gr1Rsy\nKvERy673Wco/CuDRnEYdi2aNK4wLaPVExBNc3QYdCj4gGAFjNnTjL73Pc7AOcc4cmERBA13JPKrT\nznzcoLxxBccNavQUXLEEbV80EEzegLKNE72I0TlUJXoNwUadarS1YgIVYw0ChhiVznCM9BaSRiC6\n/c7hSNM2k5dgix3YgKC9swkYpvLWNoV5DE5D9/0LZ85vqNUVGJR4ywoYKsnbjagRVwjZ74ophMQT\nTF5CQ7B5BxMYWEctIuIOE4BMiliPDdpnOodPJX4zVjRiJmDYiKbzFjzDkr64ggsKrliCDoT+s8k7\nsMEgIPYwMkyT0c3hPTjqLVbeIF4BH04HDNlR5fCfhGRvoUSw0TYkaYspGLyEERD0iUi6wfdegan7\nYNg+GKraTFP8wQWGACg4jcvx/4n2FFJvq2qjFGXqOR0w5KgkFEoocCpx8NLtNu/B5CGQ8oLiGajg\n6MsTTUEQAwr9M7Qb33CtrYbt+rcEGGm0wW18lOI0wLCivlvxRCbLfucIxMh4LfEEExQU78EIBDW2\nQNTe1CYQ6JAYjtH+iEaDx1DWfw2shuy7ngH/nqSAYcFbsHrAEqcChhzN5S2kBBwtcYdgKGhlhpGH\nHgpqN0TvNqj7d80YBl393LdVBcEAiPG5h5td/ZNGXQvtOnhiEEmeg+u4iDrM9cYfY9UMXqmAYU7l\neguuLkTQxCn9l7eZQqH9YvYCVCjsDvDgnaH70KjfD+efAEAHhaFr4fIYvN4E0uMNQcfryvg1X0PQ\nsdfxgyHH7Zoj4AiE5Sy4Up5NIxB6DMEy+jDJT9CMfgSEs93BE+gMn5sG2CkA6I2flPhD17xhuwaH\n/rheOiSm3oLlMyy/+I5/DXvzGjz7XecNVSUg5IDm+MGwdqVAwbfPNiFKhYKpHrWLoEKh39c0rQHs\nFDg0DXh3gAcTBhiwCokeAqp3ARUCMHsC6rZRgHLc/CzPIcCA5vAaxGPYgkpmORbPmDTfQdNFUUy5\nDtqwpB5T0OMJihfBOxpA0O/nfvtu7Ckw4VBOMf5DwlP7Nhi7wZMANHDo2wzXwmhcFoNzGmKwpxBW\nLrbeUC02iUrkV3LQMTTt2Xq8pwuhnscUkOzr0EYHjFBoGvBu13kLLRDQdJ/P+m0Hj4GbvivRGT9h\n4j2MP2ujEmo3Q9vm2t7u83sPkzpMKu1JRNQboxqexnGDYYZhHX8b5vEWrOe1dCtGsYW+3n6EwAAF\n9F7BWdNCoDl83p/3IGmNkncACNjvFBAM3QwbGBwew8TwMSk32j66DoHbbMcHHJdUV6Hz1NJxg2EG\nVfcWbMOTrpTnkC6EWqfWhVBHHnoocNO0INg1g4ew37Vewv68Ae+6LkTTewiEfQeIAxBI6zpon10e\nQ4C3EBx4rNi1CKrLpVpQiKxXwGBSqV/5zOcuhkynnuQsePIVjKMQiofADbWjD31Qse8+nDW4uPGs\nBcFZ233Yn7VguLjUQqDtTrRgYAL4bAyFcbei/wMM32EAgqdrMdlnvFjTTdlewlzAyDxvrI4XDDN0\nI2ZJfzbJNxJhPEbbr0KhHyFQA499ULLvPnRBxt472J+3YNirYOih0I9I9GBoFEB0YAAw7VoA6WDw\nQcKwXnG2hzA3FGa83Y4XDBuTc4gydBRiOFbzFkjJiOwNXq17MkTZAaEPNDaqh9BC4aIHwxnh4lIL\nhbZr0YFBAcWoO6F3JSYeQ2vA9mFMZfvoYihlJhfKfJnSPIjAdYszjHgNw5YCBl2B3YjNeAsqFEbb\nlS6FmsS0a7ochK5rsWvGcFChcE7YnwEXlzrvYIc2rtBg8CD07gM3PIZBiIegGmOk5zApC9iNe2YP\nAgA4/skLxc7tkoChliLiC1EJTbZj+nPaVknqt6l1G6ZQH4KR/ehE25XY7w4ewn4ARBtH2F8C9meY\neAv7Mz50I5rul7xRjF31FIbsyL6tncFoHsMBDFNYTD6bVAMKscZdwoglxpCgNQxT1lCit2BcIs3k\nLQzfmy74qHgL/QjEAIgOCufUgmEHxWtgrSvBB6+h+z4YPHVGPgGAAobRu7Ydlv3anzveEA+HoGcq\nRd52RW7TUh6HpuMEQ6pKdSNKegvqCIKrPlPqs1rGkuGoT4washj7V99lOG9wcYm6V9t92F9qvYU3\n/wGwP+cWFDuAezCc77s5FZ3hNzx8J8VraLr3YRsUOyce3fwHfvHkT9WNd/pdv7R2o3Lus+4Zq0k0\n2oQHuxWvS8CwJqUuwKJ6Bob5ENanS4+6DgYvQg0+dvGDYfThrO0+7HctFFoPgjuvgcE7Bs65hQEB\n1LSfqTlAgXAw/KYZGzoRdy+1yTx+Vy/dCB5uQPSXanpJ7EbkMvJY40sFxnC+rKPDJGCIVFVvYVrA\nvi8k+GlKfVYyHEfn6YcohwxF6rIYD/GGAyDo0FU461+M/TmAsw4KDYPO9yMYEDGa3X4weNX4h89D\n0w8Q6A2v0SChG9ihnLbdeGlMsEg3/hhjzwVDMx13KS4BQ6/SqcsllZrlaCo/KqeBol9DoRmnL/cZ\ni2pwca9/PsMBCmd7YMegsz2apjP4pvUKdgMYWgg0Axy4c1oOxq0bvw4Nk5egG93ku8GobEbvM+AQ\nA0+FQGnjb2gfVV7AUFIx6zfkeAsmTRKYRj+v0y6DafgSHQSGfIbufZS41AUQGzXQeHj1UGjO9tjt\n9mh2LRx6QJw1+wkIGmLsmv3I8FWPwQSCBjwxaFM543eD0bkMx2XctT2FObwDkwQMc6hQzkPQzMtQ\nbwGGTMdumLL9Ke/zDrrvXRdDjTfw6NXFEzoo0I6xO9ujaTowdMZ/ttuPvIHea9g1+5Fh9wZhAsPw\nrhhNb9heKJi6EEZQ+LwF/y/wLjb2UBACud0VAQNQphuRG1sIfMzcqE7r6s6at6CnP5s8CDWpSR2i\n7CZL7dV4gpKnMIw+nLcxBeo8hd3ZHpfO3xzBYNfscd7sBwj0v/pN50kArXGoRq56D73hHABxMM6d\nARZqWb28ftzoGIeBhgAhxih3iHPxc84Vo+MDQ8UchkWyHU0LvLaNcR4W5C20BQ/eQvd9tK2LNRzi\nDYoXoXQr0I06NA133Yf9AIVds8euM/7z3cUAhDMFEA3tjSBov7fGoxpxv2/4bijTl9PLjPYbDMtl\nrCXiDiHnCVEtKADHCIYtKsZbmByreQuqbHWR5RglSxEKBHogQN03ymA8DElSN/TYNDyBQvt5bwTC\nWbMfeQS9EZ9rXQQdACHdCd0AQ7oXpuNCjhkdHxHwK9GNiDmfTwKGmqrhYeTOotShMMQVxseNJzER\nhvUUNEj03sMwJNl7DX1QUYHCWQeFM9pPPIR+287gLdggoBpnb8Quo/cBArAbl89wQ40yBwAlDd8n\nAUOgVtWNsMk2YUoT2/6WYaiyh4YKA0O3oivTdyN6b4G6eMKu2Y+gcIDDxQEKHQDOmwtj10GPOQBT\nCNiMf7Td1I3QjDQFCsFAiDTqXaFAZOx5ewkYSihnmDIl6Kh/D5kw1W+zxBLG71BWfsah6zB68SjG\nQF1sYbfrvIJdG2g8310M3Ycz2uPS7s3OOxjDoP/c/lldsBL7ifGrUFCNsj/WtK2XbsTGYGTkUGao\nAceDoYx3kBqHOC4wpAQe15rY5EqPdiQ1WadXj3OLu3Mo25Qq1SXShq4DcPAYus9qjGGcyXgYnmzA\nAxTOmgsjFBraj+INqvHrgOiN2wUCFwB2nmCkzdB9hh1iyClGWgoQsfKCgYgeA/AvAbzOzP+k2/YJ\nAP8GwN90xT7OzF/o9n0MwEMALgD8O2b+4wrtnlWluhEp06utcnkLUfUc6hitu9h3HXqZANEHHbvP\nJjj072pMweQpnDUXXiDohj/5HggA3fhtRm8zSp+BxxhzatygqQyMEI/h9wD8NoDf17b/FjP/hrqB\niO4G8ACAdwN4J4BniOhdzHxRoK3bUumYRMzcCAcs2FZm5FFg/FmBwjBkqcQb1AlR1DWjjx/0ow0u\nKDS0HyCgeww2ILhgEA6IsOFLW1m1TS7FGnFsYpSxjkxweMHAzF8kojsC67sfwBPM/AaAbxPRNQD3\nAfjT5BauXTW6Iq65EQl1dBVZYcBq10LxHkZDlcAo+KgvzaZ7CT0oRt4CTMHG8ehED4je4M6p/U0x\neQcmo7eBwDciYTIkezDS060INOxU400NKMYoJ8bwi0T0rwA8B+CjzPx9ALcC+DOlzCvdtomI6AqA\nKwBwI27KaEZdVRuNcD2L0qXQR871+22zKR3ntT6fgbTuBtpFVhotzqAauuotNCootJiCDoXeK1CB\noBu/7Xu7zTI6oRmjebTC5h04RieCYgzLjEykdFdSwfA7AH4d7YjVrwP4TQD/OqYCZr4K4CoAvI1u\nXmamSO6vfckp1sOxCStAq2V83QiDdzA8oLafcq2MRhxyGKbdiWFeBeEwi1IbqmyUEYnz5mISU+hh\ncWPzw64pGhgUz0AFweHzFADqtnFwUoeC32tIHZGIS25K8wBq5jUkgYGZX+s/E9HvAvjv3ddXAdyu\nFL2t21ZfFVOhiyt3QZaU+m1eghp4HJU35DAYG6mOgPLAFH1C1OAluGIKFiiYPANTQlO/zQYDHwhi\nRil8Rhlq7CnGXcqTcCkJDER0mZmvd19/DsDz3eenAHyGiD6FNvh4F4AvZbdyIVUbjZgWiKswZKUm\nU0zBp95DcO4HJgu59t0ItHAYmqnMZ9gRj2DRvw+AcEBh6jHsnd6BDQY+EJgMLj3OEDD7MsHAa49G\n9AoZrvwsgPcCeAcRvQLg1wC8l4juQduVeBnALwAAM79ARE8CeBHAmwAePrkRiaWWlbdJf6CtaZ6E\nKx1afQ8+5XSIst2+H3kLakzB1n2weQkuINhg4ANBXLzBl9fgN/oUI58rLTpkVOIjhs2fdpR/FMCj\nOY2aRbXiCzlKHY1IhNGwKMuorsO+tiEY3qdDlTwaqtSDjofmjSdIqe89EGwxBT2WoELBBgQbDHwg\nMBmqzRB9hn+SXQlRQaWMRuSeywQS/RkT0VXz6L2tkkdA2BlGIAAcPAYNCgevYdp1aIESDwRXMFLf\nbzpelcv4Yww+qUtR2XMQMFiUFF/IGY0IrdP1WHsAw2xKTZPEJs+Qpe4hjBOaTDkMB69BzWloiHHe\nGb0+dLmjPc5JTXIavwOHPIYd9iMPQYeBKY/BHoT0ZEJGeA6m400KNeScxKSSnsRxgGHuEYnK8yuy\nYdJWcvACbPX1i6zg0HUYhixHdRm+dwHI9vvYW9BzFoA++Kh1C1Qj1gKNajkdCvp+HQopQMj1HtR2\n2BRr9LmGnuNVHAcYYrXkxKmcRVmM9Xl++SPkBILqMdjKWNTo3Qsls1FNbz6UGQcobZ6C3l0IAUIs\nDGpNqlpj90HVaYJhJhX55QfKgSwihqA+lTqs6nEOw2EIcrzwSi99vsO4K2EecTBBQfcSTEBwdRVy\nQVACAKkGXzMIKWDYktQ4QSwsXBmRgcZvnUDlOV5PVR79gtvyBEaJT9OYQvvZDIVQD8FWTm/z6Bjb\n8GVhAKQafSlYCBhKKTd/ITUVGmmeCeveg5qzoKQ+9+8+eOgPfFHzF3rpnsAwDwI88hZ0KOjHj0Ys\nLFCwAcEFg75uXcYJVr7hygJ5DjnldcWuBSFgiFWOWx8QX8jOXzBNnFLrdMUkDFOvbROqWlj06zFo\nwUfoXQZtSXjDxCgTFNphTHP3wQSEWBiETMMuvaJTjIGnrr4Uex6TTg8Ma12xKVe25d18WY+A3zMx\neBOmIr2XQOr8CM2DmCyyogxNqhrlKRhiCm0d066Dul3d5+oqTGZcRsDAOZEq0DhjASAJTqKDZkq1\nHk2Ysi3eoskbY7BkHOrGqac699sPn9VsyWnXIdZL8AEhFgb+7kW4Qacaf6mnWW0fDBVyGGZfETom\nvuD6e2OWihtGHRQvwnS47XQO78F6SnUOgydVWQ04jp845fcGTHW7ug0hQEiBQQgIYgEw17Mstw+G\nrSjAaFOCiOFLy1u6GhZN5lAMx2Ca34CDEZBizL6kpr6cS7a4gg4FZ/DR4iWkAsE+pFkwvpAAgBJL\nwvUSMFSS9/HzwRUVjokkjWBYMiKHKqeZj6p0g1NToPv9ajJT7y0cMh8NwUYNCIAhAKlBST3O1C59\nv+m76e/zlR+OizD2VCOX4coU1Qo8LvIwmvCuhvUBM/1+LZZwSI92HKTkMYybpQQb1QQnLYuxV0wU\n3xZs7LelLg1v2hcKBP8sy4DuhAQf169VxBcmZfRhRc96kZ6hSms3wSBTWdNtaXpc/eG0YcFHk7eg\nltc/W0clDF0He9eiPBD8j7MLM+wcAOT+BAoYYpTqccQ+PyIl8GgqG5L6PEpi8o9ChGZJ+mSaLKWr\nMUCgP9YWUygJhRgglIBBfCCyngQMp6qCozkU+AuoL+DSbvNkCAakT5vqioFCDSCUBkEqBHaJ/2YB\nQwUVmzwVcx6fV2JcJj50RAPBQ5N6QpO+cpMqfe0EtRvh8hbUY/Rt7Xe7FzGpwwMFY9fCFatIDEyO\n649XKgBsEjDkqmZMouBEqdAy48fUwQwEZe6EukJ0X9T3MBd1yTZT+cNxYwioIxGmLoRp9CHES0iF\nQQ4EQv+zqQZ/2jGGLS0Zb1LOsytLKuYy5uTvB05QUuVcPi3AIzBti4FCDBBKwCAFBDXuom2DobCc\nIxKVA4+Hpdk8gUffiEQhWZ9GZdps2W5azHU0qqB1F9RuRMgSbSaZ8xjKQCEFCKVhMNdPiYChsIo/\nQ6KELCtBT8rENs1gKK6YQi9bTGBSztYN0JKj+jpi8hjGD6op7yX4DDgUBslBx8TjegkYjk1Or8ew\nLyRGYoo19IbigMPhFPGJQUO5CG/hcD7DxKvCUEgBQi0Y5ELAJAHDMUoBgDXrsbDn0lDYpKHpcRlJ\nPIaUZ1W5UJgLCGsAgS4BQ44WHJHwDlWGJDh57kjTyk36067bU/mNe/QMS9McBi2+MF6PYZzQpK7h\noA5NupKX+jaY9qcCwXb5XCAIHo0ILHc4Z9l7UcCwlOYekQiFWEOHhWA1xWY9qs+rdJcL6yIElzME\nG1OhMCcQYmBQGgS6BAydVjsiEbotUMakJssDZ1JkXN7NFIdIMPLpPnOCk35sKSjUAMIcMEi5e08H\nDDMs6bboiMQiox3mzXGrIfvL2jIfzfWlxSxKQ6EEEOYEga7TAcOWZcthmEnGVaJp/E4B3Qb3Y97M\n8QVX+fY9Lclp9BSsgO6DsQ2RUAj1DmKBIAlOa9IaHnfvWuU58Liha9GEz51ImWGppjCbXHzXMf1n\nGwSGMo5RiBQomAzOBAPniIRj36HOsAuaNIcisU8oYFijjmQl6wbTxV3N5exlUlKih2MXhIIPCGuE\ngSoBwxKae0TCsGx8kHcQmBZtGq7MyU9wqfSDXEzH1YRCLSCUgIEqAYNPR/LrnazI+82c5WifPBUy\nBOkq4/MWRtss3sJaoBBzp5UGgS5vW4jodiL6EyJ6kYheIKJf6rbfTERPE9E3u/e3K8d8jIiuEdFL\nRPT+mn8ACmpEAAAMO0lEQVRACc2+nJt67tzRhIR1GLz7bIdUvEx64NG3NqTpuyvgaF1QxbvykqGt\nxnrsUNgROaHQWOo01gVKgkJTIaD5JoCPMvPdAP4ZgIeJ6G4AjwB4lpnvAvBs9x3dvgcAvBvABwD8\nJyKaI4tzUVUZqkwBVkg6tENRgUXrcKUtbdj81Cmb7PkJvpWcfMaePupgg4L5eDcQbPVN66ckIDRE\nwytW3nYx83Vm/kr3+QcAvgHgVgD3A3i8K/Y4gA91n+8H8AQzv8HM3wZwDcB90S0rqWPoDvR/Q9Ck\nJ0M6dOTTrq3Dk9p3dcl4V2r0OOHJPcdBlW2a9rgeT4JTYBdCvUt0KJh+1W1eggsIjfYyt5uiYKAC\nIAcGejuDRUR3APhxAH8O4BZmvt7t+h6AW7rPtwL4rnLYK92249EahipTlcLIyn9uyQelOKd7Wz0Z\nvZz/PC4vwSZ/0lO4V1AKADYFBx+J6EcA/CGAX2bmv1NdZ2ZmCl0R9FDfFQBXAOBG3BRzqEjX3FmP\nwYu/7ouMToSsKO06JmZ/SPehNBRiuggpIEiKSYQUIqJztFD4A2b+o27za0R0udt/GcDr3fZXAdyu\nHH5bt20kZr7KzPcy873nuCG64SevwjAYPcw2tikJxwyLxgYa+vT4cTeinV1pH4kI9RZ8+2Oh4Ass\nxnoIMUoNVAJhoxIE4NMAvsHMn1J2PQXgwe7zgwA+r2x/gIhuIKI7AdwF4EtJrduyUnMVjiEegnE8\nINRrUEckpqs3l5svkbpac0o8wd4Gv9GmdBdSA5W6QroSPwXg5wF8nYi+2m37OIBPAniSiB4C8B0A\nHwYAZn6BiJ4E8CLaEY2Hmfkiq5VL6UiMtKh8SzwUfOZiqjcxqTshthDqKdiU6yWkeAcl5QUDM/8v\n2G+H91mOeRTAoxntOi5Z/snjxVYy/7GxT6kaPtuLTSZPBZ7Cuhy8Y5HXEOnxBdPcCNe0an3/uG2H\nz2ELuKZ5CS6FwqB2chMgmY+b1FwPtPFKAUBk7DlYJR/gmgqFUG8hFQqxXYUYNYlzLwUMa1WFIdHR\n/AjH/RLz0FtV7qHC6ePjbN9dCo8PuMvlLLFm8hZcOQnOdlTyElKB0Gu7YFjqV3OLOQw1rpW2HkNN\nubIlg6dwRwxPOuuZGQpzA6HXdsEQqmMOIOojH7HQCl3mLUO1Zln6FmIZthmHMEPPoddVBgo1vIRS\nQOh1/GDYukoGKFPPmyj3Q2f62ZXlweHrRgxtMKQ9D/smZctc+9JeQmkg9BIw1JArhyElvyHH6yn0\noNuU0YkY6TkM+gxLNQ4RvJCscaEWs1xQsMkcqEzzFGrDIBZsAgabluiCbLTbY1yDgdKHJUMVGl/I\nPk9gF6I2FOYAQi8BQwGtZvhQ1wLtqmmkISMSrm5EKW+hJBRCFQuF3K6PgKG2Zp/g5DnfiiBWKrMx\nRaGjEbkGluspzA2EXicPhqVWbyrmZVhGFiaLtHiBkbb6c4zUx9PFHJOi0KBmrHMe4y3MCQV5RN0x\nakO5ESHw8HUn9P3+BV5di7UosyudS7sp2yx/g28kogQUSgKh5mPqBAwiu7T7LsejCB1CDFWJVGn3\nE6r9ULDWWxkKtZ9bCQgY1qk1eRCupoxSLMIeYDuHauRGGM9juDipgcZa+QipdQsYTl0rCka6ZJtB\nGaLYbkTIL3JsqrJz1KJi10EmUZ2I1jY06muOb4KUaSp1sXUYCndffMrpQvgU/zzLU51EJUpW6uzJ\ncR1+o3NBwZT0pD+rMlS5APDlLkwXbZm3CxEDBZlEFaIlMglLpkMnPKS2iBZwSkxegmt5t/Z72KSp\nwz71fLYy7qBjDBRyuw9LAOFQn2gbWlNAMlKlRyS2oC1DATh2j2EGLdbnz30wrqXd/ZBkbrLT0jAI\n7V64uhE1uxAuhT/4tuZIhqieVhYozPpvL/SnxKzu5KxnJf8KnzGvAQpt/aKTVbBX4El0Sl3vcY58\nA9MNHhpfGO2LIKM1G3JBKDSRZD/prsSST7kurpX8La4uRPtE6jwPwPbU6wYcDZqYboSxTEGPsBYU\nYoHQa5tgWJuLHqmiy8aHaCXQsCnlATHu1aHiPZHoPIHIkQiXQYecey4g9NomGJbSyg0sWYU7lL7A\nY6m4QahinxmRejlSuxA+xRyfC4RDPSKRyKmaD3jxeQtLQKGtSyTamFKfPVlKpm5EjS7EUlBo6xMd\nj+aIvSSeInfdx9QFW0KkGmhJg8iNKywpAcPaFBLHWPlNlSN9deiwY+p5ELonEOMt5GhJbwGQ4GNZ\n5WYjxqrA0vC9mCgruEpIy3a0Pd4+pLsQ+tAZ87FlFNuFKDUCUQMG4/pFolDp92LWik5+r6Bm96FX\nTFJTjfRnXbWgsIucUChgMKnGrMy5vQmbZu6GhK7qFNJ9iMlPWMnVHqlksDHuvCmZkqJkrW3RFJdS\n1mAIOsZh+GtZ6m1u1Z7HEKMUKAAChuNWkQVZCrRjBQp5qIzLGGp3I0JhEtONSIUCcMzBx40+7m2Q\n4UYM8lDm8mI2AgzXrMrcSVPGadgJQcfScYUcIBzO5xER3U5Ef0JELxLRC0T0S932TxDRq0T01e71\nQeWYjxHRNSJ6iYjen91KUZS4oVUNaebkMASPMhxxt2VuKABhHsObAD7KzF8horcC+Asierrb91vM\n/BtqYSK6G8ADAN4N4J0AniGidzHzRZEWH6sW8nC21lWYLPeWsXp0Xjvm8RaWgEJ7Xo+Y+Tozf6X7\n/AMA3wBwq+OQ+wE8wcxvMPO3AVwDcF+JxpbUUU25FmVrHIPY3r1REgpAZPCRiO4A8OMA/rzb9ItE\n9DUieoyI3t5tuxXAd5XDXoEBJER0hYieI6Lnfog3oht+MqJmk7M6Q0YkcmZZurwD/aaOfZp1ipb2\nFkorGAxE9CMA/hDALzPz3wH4HQA/BuAeANcB/GbMiZn5KjPfy8z3nuOGmEOX0QaNM1Vr617Mkejk\nPv/4gqzNoyjtLQCBYCCic7RQ+ANm/iMAYObXmPmCmfcAfheH7sKrAG5XDr+t2ybSVQI2KUHGwvdR\n6NJu7dOuZ4wDJFyaFKNf0luoAYX2/B5RO0b2aQDfYOZPKdsvK8V+DsDz3eenADxARDcQ0Z0A7gLw\npXJNFh2bcmde5irGtEp4C6USoGpBAQgblfgpAD8P4OtE9NVu28cBfISI7gHAAF4G8AsAwMwvENGT\nAF5EO6LxsIxIHIEC7WEOt39OryM1sSlnWnWIt1ATCgBAzMuP/xLR3wD4fwD+dum2BOgd2EY7ge20\ndSvtBLbTVlM7/zEz/2jIwasAAwAQ0XPMfO/S7fBpK+0EttPWrbQT2E5bc9u58bxhkUhUQwIGkUg0\n0ZrAcHXpBgRqK+0EttPWrbQT2E5bs9q5mhiDSCRaj9bkMYhEopVocTAQ0Qe66dnXiOiRpduji4he\nJqKvd1PLn+u23UxETxPRN7v3t/vqqdCux4jodSJ6XtlmbdeSU+EtbV3dtH3HEgOruq6zLIXAzIu9\n0M5p+Wu0cy4uAfhLAHcv2SZDG18G8A5t238E8Ej3+REA/2GBdv00gJ8A8LyvXQDu7q7tDQDu7K75\nbuG2fgLAvzeUXaytAC4D+Inu81sB/FXXnlVdV0c7i13TpT2G+wBcY+ZvMfPfA3gC7bTttet+AI93\nnx8H8KG5G8DMXwTwf7XNtnYtOhXe0labFmsr25cYWNV1dbTTpuh2Lg2GoCnaC4vRLjbzF0R0pdt2\nCzNf7z5/D8AtyzRtIlu71nqdk6ft15a2xMBqr2vJpRBULQ2GLeg9zHwPgJ8F8DAR/bS6k1tfbXVD\nO2ttl6Ksafs1ZVhiYNCarmvppRBULQ2G1U/RZuZXu/fXAXwOrQv2Wj+7tHt/fbkWjmRr1+quM690\n2r5piQGs8LrWXgphaTB8GcBdRHQnEV1Cu1bkUwu3aRARvaVb5xJE9BYAP4N2evlTAB7sij0I4PPL\ntHAiW7tWNxV+jdP2bUsMYGXXdZalEOaI9noirB9EG1X9awC/unR7tLb9GNpo7l8CeKFvH4B/COBZ\nAN8E8AyAmxdo22fRuos/RNtnfMjVLgC/2l3jlwD87Ara+l8AfB3A17ob9/LSbQXwHrTdhK8B+Gr3\n+uDarqujncWuqWQ+ikSiiZbuSohEohVKwCASiSYSMIhEookEDCKRaCIBg0gkmkjAIBKJJhIwiESi\niQQMIpFoov8PYXGIIWdZo90AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f2448486f28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(cdf)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Interpolate the cumulative distribution\n",
+    "\n",
+    "Here, we also create the Python equivalent to the getPixelSignature function.\n",
+    "\n",
+    "Note that the ground truth is not symmetric about the center pixel because of the finite sampling of the CDF; it becomes more symmetric the smaller resPSF is and the larger sizeX/Y are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = (resPSF * (xy[1] - x0))[0]\n",
+    "y = (resPSF * (xy[0] - y0))[:,0]\n",
+    "\n",
+    "# Compute the interpolated CDF\n",
+    "f = RectBivariateSpline(x, y, cdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def generatePixelSignature(pX, pY, eX, eY, eZ):\n",
+    "    value = f((pX - eX + 0.5) * resLateral, (pY - eY + 0.5) * resLateral) + \\\n",
+    "            f((pX - eX - 0.5) * resLateral, (pY - eY - 0.5) * resLateral) - \\\n",
+    "            f((pX - eX + 0.5) * resLateral, (pY - eY - 0.5) * resLateral) - \\\n",
+    "            f((pX - eX - 0.5) * resLateral, (pY - eY + 0.5) * resLateral)\n",
+    "    return value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.02800397]])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(0, 0, 0, -1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.03726069]])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(1, 1, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.02800397]])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(2, 1, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.03077785]])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(0, 1, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.02800397]])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(1, 2, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.03077785]])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(1, 0, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.01628886]])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(-1, 1, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.01377306]])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generatePixelSignature(3, 1, 1, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Added
- There is now a `GibsonLanniPSF` for modeling realistic 3D PSF's and
  that can account for details such as sample, coverslip, and
  immersion media refractive indexes and thicknesses.
- A `PSFBuilder` interface was added to allow for a PSF to be built at
  various times during the simulation, rather than all at once. This
  addition is necessary to account for axial stage positions that
  might change during the simulation.