### PR TITLE
Improve Gibson-Lanni PSF model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
   computational grid.
 - The `GibsonLanniPSF.Builder` also now has a `maxRadius()` method for
   setting an upper limit on the size of the area that the PSF is drawn
-  onto. Reducing it can signficantly speed up simulation times.
+  onto. Reducing it can significantly speed up simulation times.
 
 ### Fixed
 - PSF instances are not, in fact, immutable because their fields are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+- The `GibsonLanniPSF` now caches computation results to avoid
+  repetitive calculations.
+- The `GibsonLanniPSF.Builder` now has a `solver()` method for setting
+  the solver for the Bessel function coefficients. It accepts either
+  "svd" or "qrd" as arguments. (SVD stands for singular value
+  decomposition and QRD stands for QR decomposition.)
+- The `GibsonLanniPSF.Builder` also now has a `resPSFAxial()` method
+  for determining the spacing between axial planes of the
+  computational grid.
+- The `GibsonLanniPSF.Builder` also now has a `maxRadius()` method for
+  setting an upper limit on the size of the area that the PSF is drawn
+  onto. Reducing it can signficantly speed up simulation times.
+
+### Fixed
+- PSF instances are not, in fact, immutable because their fields are
+  not `final`.
+
 ## [v0.5.0]
 Contains [ALICA v0.2.1]	
 

--- a/nbproject/configs/GibsonLanniPSF.properties
+++ b/nbproject/configs/GibsonLanniPSF.properties
@@ -1,0 +1,1 @@
+main.class=ch.epfl.leb.sass.simulator.generators.realtime.psfs.ProfileGibsonLanniPSF

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -82,9 +82,16 @@ psfBuilder.tg(170);          // Coverslip actual thickness
 psfBuilder.resPSF(0.0215);   // Resolution of the calculation grid.
                              // Should be >= 5 times the object space
                              // pixel size in microns.
-psfBuilder.solver("svd");    // Can be either "svd" or "qrd". SVD is
+psfBuilder.resPSFAxial(0.005); // The axial resolution of the
+                               // computational grid.
+psfBuilder.solver("qrd");    // Can be either "svd" or "qrd". SVD is
                              // is slow but accurate, "qrd" is fast
                              // but less accurate.
+//psfBuilder.maxRadius(4);   // Use this to reduce the number of
+                             // pixels that the PSF is drawn onto.
+                             // This can significantly speed up
+                             // simulation times. Otherwise, don't set
+                             // it or leave it at a large number (>20)
 
 // Fluorophore dynamics and properties; rates are in units of 1/frames
 PalmDynamics.Builder fluorPropBuilder = new PalmDynamics.Builder();
@@ -145,7 +152,7 @@ for (i=0;i<1000;i++) {
 }
 
 // save and show; uncomment these lines to save and display stack
-generator.saveStack(new File("generated_stack.tif"));
+//generator.saveStack(new File("generated_stack.tif"));
 //import ij.ImagePlus;
 //ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
 //ip.show();

--- a/scripts/example_Gibson_Lanni_PSF.bsh
+++ b/scripts/example_Gibson_Lanni_PSF.bsh
@@ -82,6 +82,9 @@ psfBuilder.tg(170);          // Coverslip actual thickness
 psfBuilder.resPSF(0.0215);   // Resolution of the calculation grid.
                              // Should be >= 5 times the object space
                              // pixel size in microns.
+psfBuilder.solver("svd");    // Can be either "svd" or "qrd". SVD is
+                             // is slow but accurate, "qrd" is fast
+                             // but less accurate.
 
 // Fluorophore dynamics and properties; rates are in units of 1/frames
 PalmDynamics.Builder fluorPropBuilder = new PalmDynamics.Builder();
@@ -142,7 +145,7 @@ for (i=0;i<1000;i++) {
 }
 
 // save and show; uncomment these lines to save and display stack
-//generator.saveStack(new File("generated_stack.tif"));
+generator.saveStack(new File("generated_stack.tif"));
 //import ij.ImagePlus;
 //ImagePlus ip = new ImagePlus("Simulation output", generator.getStack());
 //ip.show();

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -25,13 +25,14 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.SingularValueDecomposition;
 import org.apache.commons.math3.special.BesselJ;
 import org.apache.commons.math3.analysis.interpolation.PiecewiseBicubicSplineInterpolatingFunction;
-import org.apache.commons.math3.exception.OutOfRangeException;
 
+import java.lang.Math;
 import ij.ImageStack;
 import ij.process.FloatProcessor;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.HashMap;
 
 /**
  * Computes an emitter PSF based on the Gibson-Lanni model.
@@ -136,6 +137,11 @@ public final class GibsonLanniPSF implements PSF {
     private double resPSF = 0.02;
     
     /**
+     * The spacing between discrete axial planes for the PSF computation.
+     */
+    private double resPSFAxial = 0.005;
+    
+    /**
      * The emitter's x-position [pixels].
      */
     private double eX = 0;
@@ -151,6 +157,15 @@ public final class GibsonLanniPSF implements PSF {
     private double eZ = 0;
     
     /**
+     * The maximum radius from the center for drawing the PSF.
+     * 
+     * If this value is smaller than that calculated by the getRadius() method,
+     * then this one is returned instead. This can help speed up simulations
+     * where most of the fluorophores lie near the same focal plane.
+     */
+    private double maxRadius = 30;
+    
+    /**
      * The displacement of the stage away from the surface of the coverslip.
      * 
      * Negative numbers correspond to moving the stage downwards, which, for an
@@ -164,12 +179,7 @@ public final class GibsonLanniPSF implements PSF {
      * information.
      */
     private final double MINWAVELENGTH = 0.436;
-    
-    /**
-     * The spline representation of the PSF.
-     */
-    private PiecewiseBicubicSplineInterpolatingFunction interpCDF;
-    
+      
     /**
      * The name of the linear algebra solver used to compute Bessel series coefficients.
      * 
@@ -178,6 +188,16 @@ public final class GibsonLanniPSF implements PSF {
      */
     private String solverName = "qrd";
     
+    /**
+     * Reference to the interpolator for this emitter's current position.
+     */
+    private PiecewiseBicubicSplineInterpolatingFunction interpCDF ;
+    
+    /**
+     * Cache for PSF  interpolators.
+     */
+    private static HashMap<Long, PiecewiseBicubicSplineInterpolatingFunction>
+                        interpolators = new HashMap<>();
     
     public static class Builder implements PSFBuilder {
         
@@ -199,9 +219,11 @@ public final class GibsonLanniPSF implements PSF {
         private double tg;
         private double resLateral;
         private double resPSF;
+        private double resPSFAxial;
         private double eX;
         private double eY;
         private double eZ;
+        private double maxRadius;
         private double stageDisplacement;
         private String solver;
         
@@ -236,6 +258,14 @@ public final class GibsonLanniPSF implements PSF {
         }
         public Builder resPSF(double resPSF) { 
             this.resPSF = resPSF;
+            return this;
+        }
+        public Builder resPSFAxial(double resPSFAxial) {
+            this.resPSFAxial = resPSFAxial;
+            return this;
+        }
+        public Builder maxRadius(double maxRadius) {
+            this.maxRadius = maxRadius;
             return this;
         }
         public Builder stageDisplacement(double stageDisplacement) {
@@ -293,14 +323,20 @@ public final class GibsonLanniPSF implements PSF {
         this.tg = builder.tg;
         this.resLateral = builder.resLateral;
         this.resPSF = builder.resPSF;
+        this.resPSFAxial = builder.resPSFAxial;
         this.eX = builder.eX;
         this.eY = builder.eY;
         this.eZ = builder.eZ;
+        this.maxRadius = builder.maxRadius;
         this.stageDisplacement = builder.stageDisplacement;
         this.solverName = builder.solver;
         
         // Compute the signature for this PSF.
         this.computeDigitalPSF(this.stageDisplacement);
+        
+        // Set the interpolator for this emitter's z-plane.
+        Long zPlane = getNearestZPlane(eZ);
+        this.interpCDF = interpolators.get(zPlane);
     }
     
     /**
@@ -332,7 +368,13 @@ public final class GibsonLanniPSF implements PSF {
     public void generateSignature(ArrayList<Pixel> pixels) {
         double signature;
         
-        this.computeDigitalPSF(this.stageDisplacement); // Compute the PSF
+        // Compute the PSF
+        this.computeDigitalPSF(this.stageDisplacement); 
+        
+        // Get the interpolator for this emitter's z-plane.
+        Long zPlane = getNearestZPlane(eZ);
+        this.interpCDF = interpolators.get(zPlane);
+        
         for(Pixel pixel: pixels) {
             try {
                 signature = this.generatePixelSignature(pixel.x, pixel.y);
@@ -350,29 +392,41 @@ public final class GibsonLanniPSF implements PSF {
      * Computes the half-width of the PSF for determining which pixels contribute to the emitter signal.
      * 
      * This number is based on the greatest horizontal or vertical extent of the
-     * grid that the PSF is computed on.
+     * grid that the PSF is computed on. If maxRadius is smaller than that
+     * determined by the PSF's computational grid, then maxRadius is returned.
      * 
      * @return The width of the PSF.
      */
     @Override
     public double getRadius() {
-        double minSize = (double) Math.min(this.sizeX, this.sizeY) / 2;
-        return this.resPSF / this.resLateral * minSize - 1;
+        double minPixel = (double) Math.min(this.sizeX, this.sizeY) / 2;
+        double minSize =  this.resPSF / this.resLateral * minPixel - 1;
+        return Math.min(minSize, this.maxRadius);
     }
     
     /**
      * Computes a digital representation of the PSF.
      * 
+     * @param z The stage displacement.
      * @return An image stack of the PSF.
      **/
-    private ImageStack computeDigitalPSF(double z) {
+    private void computeDigitalPSF(double z) {
+        
+        // Has a PSF has already been computed for this emitter's z-plane?
+        Long zDiscrete = getNearestZPlane(this.eZ);
+        if (interpolators.containsKey(zDiscrete)) {
+            // PSF already computed for this z-plane, so don't do anything.
+            return;
+        }
+        
+        // Otherwise, compute the PSF and store the result in the hash map
         double x0 = (this.sizeX - 1) / 2.0D;
         double y0 = (this.sizeY - 1) / 2.0D;
 
         double xp = x0;
         double yp = y0;
 
-        ImageStack stack = new ImageStack(this.sizeX, this.sizeY);
+        //ImageStack stack = new ImageStack(this.sizeX, this.sizeY);
 
         int maxRadius = (int) Math.round(Math.sqrt((this.sizeX - x0)
                         * (this.sizeX - x0) + (this.sizeY - y0) * (this.sizeY - y0))) + 1;
@@ -558,8 +612,8 @@ public final class GibsonLanniPSF implements PSF {
             mgridY[y] = (y - 0.5 * (this.sizeY - 1)) * this.resPSF;
         }
         
-        stack.addSlice(new FloatProcessor(this.sizeX, this.sizeY, pixel));
-        stack.addSlice(new FloatProcessor(this.sizeX, this.sizeY, CDF));
+        //stack.addSlice(new FloatProcessor(this.sizeX, this.sizeY, pixel));
+        //stack.addSlice(new FloatProcessor(this.sizeX, this.sizeY, CDF));
         
         // Reshape CDF for interpolation
         double[][] rCDF = new double[this.sizeY][this.sizeX];
@@ -573,6 +627,22 @@ public final class GibsonLanniPSF implements PSF {
         this.interpCDF = new PiecewiseBicubicSplineInterpolatingFunction(
                 mgridX, mgridY, rCDF);
         
-        return stack;
+        interpolators.put(zDiscrete,
+                    new PiecewiseBicubicSplineInterpolatingFunction(
+                            mgridX, mgridY, rCDF));
+    }
+    
+    /**
+     * Computes the z-coordinate of the closest axial plane to the emitter.
+     * 
+     * The coordinate of the plane is an integer
+     * 
+     * @param z The z-value of the emitter.
+     * @return The z-coordinate of the nearest computational plane.
+     */
+    private Long getNearestZPlane(double z) {
+        long zDiscrete;
+        zDiscrete = Math.round(z / this.resPSFAxial);
+        return zDiscrete;
     }
 }

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/ProfileGibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/ProfileGibsonLanniPSF.java
@@ -48,6 +48,7 @@ public class ProfileGibsonLanniPSF {
         double tg = 170;
         double resLateral = 0.1;
         double resPSF = 0.02;
+        double resPSFAxial = 0.005;
         double stageDisplacement = -2;
         String solver = "qrd";
         
@@ -57,9 +58,14 @@ public class ProfileGibsonLanniPSF {
                 .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
                 .resLateral(resLateral).oversampling(oversampling)
                 .resPSF(resPSF).stageDisplacement(stageDisplacement)
-                .solver(solver);
+                .solver(solver).resPSFAxial(resPSFAxial);
 		
         GibsonLanniPSF psf = builder.build();
+        
+        // Create the pixel signature
+        //builder.eX(0).eY(-1).eZ(2);
+        //psf = builder.build();
+        //double signature = psf.generatePixelSignature(0, 0);
         
         //ImageStack stack = psf.computeDigitalPSF(-5);
         //ImagePlus imp = new ImagePlus("Gibson-Lanni PSF", stack);

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/ProfileGibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/ProfileGibsonLanniPSF.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.sass.simulator.generators.realtime.psfs;
+
+import ij.ImageStack;
+import ij.ImagePlus;
+import ij.io.FileSaver;
+
+/**
+ *
+ * Demonstrates how to create a Gibson-Lanni PSF.
+ * 
+ * @author Kyle M. Douglass
+ */
+public class ProfileGibsonLanniPSF {
+    
+    public static void main(String args[]) {
+        
+        int numBasis = 100;
+        int numSamples = 1000;
+        int oversampling = 2;
+        int sizeX = 1024;
+        int sizeY = 1024;
+        double NA = 1.4;
+        double wavelength = 0.610;
+        double ns = 1.33;
+        double ng0 = 1.5;
+        double ng = 1.5;
+        double ni0 = 1.5;
+        double ni = 1.5;
+        double ti0 = 150;
+        double tg0 = 170;
+        double tg = 170;
+        double resLateral = 0.1;
+        double resPSF = 0.02;
+        double stageDisplacement = -2;
+        String solver = "qrd";
+        
+        GibsonLanniPSF.Builder builder = new GibsonLanniPSF.Builder();
+        builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
+                .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
+                .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
+                .resLateral(resLateral).oversampling(oversampling)
+                .resPSF(resPSF).stageDisplacement(stageDisplacement)
+                .solver(solver);
+		
+        GibsonLanniPSF psf = builder.build();
+        
+        //ImageStack stack = psf.computeDigitalPSF(-5);
+        //ImagePlus imp = new ImagePlus("Gibson-Lanni PSF", stack);
+        //imp.show();
+        //FileSaver saver = new FileSaver(imp);
+        //saver.saveAsTiff("/home/douglass/Desktop/psf.tif");
+	}
+    
+}

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
@@ -59,12 +59,14 @@ public class GibsonLanniPSFTest {
         double resLateral = 0.1;
         double resPSF = 0.02;
         double stageDisplacement = -2;
+        String solver = "svd";
                 
         builder.numBasis(numBasis).numSamples(numSamples).sizeX(sizeX)
                 .sizeY(sizeY).NA(NA).wavelength(wavelength).ns(ns).ng0(ng0)
                 .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
                 .resLateral(resLateral).oversampling(oversampling)
-                .resPSF(resPSF).stageDisplacement(stageDisplacement);
+                .resPSF(resPSF).stageDisplacement(stageDisplacement)
+                .solver(solver);
 	
         this.builder = builder;
     }

--- a/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
+++ b/test/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSFTest.java
@@ -58,6 +58,8 @@ public class GibsonLanniPSFTest {
         double tg  = 170;
         double resLateral = 0.1;
         double resPSF = 0.02;
+        double resPSFAxial = 0.005;
+        double maxRadius = 45;
         double stageDisplacement = -2;
         String solver = "svd";
                 
@@ -66,7 +68,7 @@ public class GibsonLanniPSFTest {
                 .ng(ng).ni0(ni0).ni(ni).ti0(ti0).tg0(tg0).tg(tg)
                 .resLateral(resLateral).oversampling(oversampling)
                 .resPSF(resPSF).stageDisplacement(stageDisplacement)
-                .solver(solver);
+                .solver(solver).resPSFAxial(resPSFAxial).maxRadius(maxRadius);
 	
         this.builder = builder;
     }
@@ -152,6 +154,17 @@ public class GibsonLanniPSFTest {
         this.builder.eZ(2);
         psf = builder.build();
         assertEquals(psf.getRadius(), 24.6, 0.1);
+    }
+    
+    /**
+     * Test of getRadius method, of class GibsonLanniPSF, with maxRadius small.
+     */
+    @Test
+    public void testGetRadiusSmallMaxRadius() {
+        PSF psf;
+        this.builder.eZ(2).maxRadius(3);
+        psf = builder.build();
+        assertEquals(psf.getRadius(), 3, 0.1);
     }
     
 }


### PR DESCRIPTION
### Changed
- The `GibsonLanniPSF` now caches computation results to avoid repetitive calculations.
- The `GibsonLanniPSF.Builder` now has a `solver()` method for setting the solver for the Bessel function coefficients. It accepts either "svd" or "qrd" as arguments. (SVD stands for singular value decomposition and QRD stands for QR decomposition.)
- The `GibsonLanniPSF.Builder` also now has a `resPSFAxial()` method for determining the spacing between axial planes of the computational grid.
- The `GibsonLanniPSF.Builder` also now has a `maxRadius()` method for setting an upper limit on the size of the area that the PSF is drawn onto. Reducing it can significantly speed up simulation times.