### PR TITLE
Replaced time_on in FrameLogger with fluorophore brightness

### DIFF
--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Fluorophore.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Fluorophore.java
@@ -194,14 +194,17 @@ public class Fluorophore extends Emitter {
                 remaining_time = 0.0;
             }
         }
+        // The brightness of the fluorophore
+        double brightness = flicker(on_time*signal);
+        
         // If the fluorophore was on during that frame, write a line in the frame logger
         if (on_time > 0.0) {
             // Round time_elapsed to the lower integer, to get the current frame
             // If on_time = 1.0, then frame = int(time_elapsed), hence 0.9999 rather than 1
             int frame = (int) (time_elapsed + 0.999999);
-            frameLogger.logFrame(frame, this.getId(), this.x, this.y, this.z, on_time);
+            frameLogger.logFrame(frame, this.getId(), this.x, this.y, this.z, brightness);
         }
-        return flicker(on_time*signal);
+        return brightness;
     }
 }
 

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Fluorophore.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Fluorophore.java
@@ -202,7 +202,7 @@ public class Fluorophore extends Emitter {
             // Round time_elapsed to the lower integer, to get the current frame
             // If on_time = 1.0, then frame = int(time_elapsed), hence 0.9999 rather than 1
             int frame = (int) (time_elapsed + 0.999999);
-            frameLogger.logFrame(frame, this.getId(), this.x, this.y, this.z, brightness);
+            frameLogger.logFrame(frame, this.getId(), this.x, this.y, this.z, brightness, on_time);
         }
         return brightness;
     }

--- a/src/ch/epfl/leb/sass/simulator/loggers/FrameLogger.java
+++ b/src/ch/epfl/leb/sass/simulator/loggers/FrameLogger.java
@@ -40,6 +40,7 @@ public class FrameLogger extends AbstractLogger{
     private ArrayList<Double> y = new ArrayList();
     private ArrayList<Double> z = new ArrayList();
     private ArrayList<Double> brightness = new ArrayList();
+    private ArrayList<Double> time_on = new ArrayList();
 
 
     /**
@@ -64,8 +65,9 @@ public class FrameLogger extends AbstractLogger{
      * @param z z-position of the emitter
      * @param brightness the apparent brightness of the fluorophore on the frame
      * in number of photons
+     * @param time_on the amount of time the emitter "id" stays on in the current frame
      */
-    public void logFrame(int frame, int id, double x, double y, double z, double brightness) {
+    public void logFrame(int frame, int id, double x, double y, double z, double brightness, double time_on) {
         if ( !(this.performLogging) )
             return;
 
@@ -75,6 +77,7 @@ public class FrameLogger extends AbstractLogger{
         this.y.add(y);
         this.z.add(z);
         this.brightness.add(brightness);
+        this.time_on.add(time_on);
     }
 
     public ArrayList<Integer> getFrame() { return this.frame; }
@@ -96,6 +99,8 @@ public class FrameLogger extends AbstractLogger{
     }
 
     public ArrayList<Double> getBrightness() { return this.brightness; }
+    
+    public ArrayList<Double> getTimeOn() { return this.time_on; }
 
     /**
      * Saves the state of the logger to a file.
@@ -110,17 +115,18 @@ public class FrameLogger extends AbstractLogger{
         FileWriter fileWriter = new FileWriter(this.filename);
         PrintWriter printWriter = new PrintWriter(fileWriter);
 
-        printWriter.println("frame,id,x,y,z,brightness");
+        printWriter.println("frame,id,x,y,z,brightness,time_on");
 
         for(int ctr = 0; ctr < this.frame.size(); ctr++) {
             printWriter.printf(
-                    "%d,%d,%.4f,%.4f,%.4f,%.4f%n",
+                    "%d,%d,%.4f,%.4f,%.4f,%.4f,%.4f%n",
                     this.frame.get(ctr),
                     this.id.get(ctr),
                     this.x.get(ctr),
                     this.y.get(ctr),
                     this.z.get(ctr),
-                    this.brightness.get(ctr)
+                    this.brightness.get(ctr),
+                    this.time_on.get(ctr)
             );
         }
 
@@ -140,5 +146,6 @@ public class FrameLogger extends AbstractLogger{
         this.y = new ArrayList();
         this.z = new ArrayList();
         this.brightness = new ArrayList();
+        this.time_on = new ArrayList();
     }
 }

--- a/src/ch/epfl/leb/sass/simulator/loggers/FrameLogger.java
+++ b/src/ch/epfl/leb/sass/simulator/loggers/FrameLogger.java
@@ -39,7 +39,7 @@ public class FrameLogger extends AbstractLogger{
     private ArrayList<Double> x = new ArrayList();
     private ArrayList<Double> y = new ArrayList();
     private ArrayList<Double> z = new ArrayList();
-    private ArrayList<Double> time_on = new ArrayList();
+    private ArrayList<Double> brightness = new ArrayList();
 
 
     /**
@@ -62,9 +62,10 @@ public class FrameLogger extends AbstractLogger{
      * @param x x-position of the emitter
      * @param y y-position of the emitter
      * @param z z-position of the emitter
-     * @param time_on the amount of time the emitter "id" stays on in the current frame
+     * @param brightness the apparent brightness of the fluorophore on the frame
+     * in number of photons
      */
-    public void logFrame(int frame, int id, double x, double y, double z, double time_on) {
+    public void logFrame(int frame, int id, double x, double y, double z, double brightness) {
         if ( !(this.performLogging) )
             return;
 
@@ -73,7 +74,7 @@ public class FrameLogger extends AbstractLogger{
         this.x.add(x);
         this.y.add(y);
         this.z.add(z);
-        this.time_on.add(time_on);
+        this.brightness.add(brightness);
     }
 
     public ArrayList<Integer> getFrame() { return this.frame; }
@@ -94,7 +95,7 @@ public class FrameLogger extends AbstractLogger{
         return this.z;
     }
 
-    public ArrayList<Double> getTimeOn() { return this.time_on; }
+    public ArrayList<Double> getBrightness() { return this.brightness; }
 
     /**
      * Saves the state of the logger to a file.
@@ -109,7 +110,7 @@ public class FrameLogger extends AbstractLogger{
         FileWriter fileWriter = new FileWriter(this.filename);
         PrintWriter printWriter = new PrintWriter(fileWriter);
 
-        printWriter.println("frame,id,x,y,z,time_on");
+        printWriter.println("frame,id,x,y,z,brightness");
 
         for(int ctr = 0; ctr < this.frame.size(); ctr++) {
             printWriter.printf(
@@ -119,7 +120,7 @@ public class FrameLogger extends AbstractLogger{
                     this.x.get(ctr),
                     this.y.get(ctr),
                     this.z.get(ctr),
-                    this.time_on.get(ctr)
+                    this.brightness.get(ctr)
             );
         }
 
@@ -138,6 +139,6 @@ public class FrameLogger extends AbstractLogger{
         this.x = new ArrayList();
         this.y = new ArrayList();
         this.z = new ArrayList();
-        this.time_on = new ArrayList();
+        this.brightness = new ArrayList();
     }
 }

--- a/test/ch/epfl/leb/sass/simulator/loggers/FrameLoggerTest.java
+++ b/test/ch/epfl/leb/sass/simulator/loggers/FrameLoggerTest.java
@@ -61,10 +61,11 @@ public class FrameLoggerTest {
         double y = 2.5;
         double z = 0.7;
         double brightness = 0.8;
+        double time_on = 0.8;
         logger.setPerformLogging(true);
 
         // Method call to test is here.
-        logger.logFrame(frame, id, x, y, z, brightness);
+        logger.logFrame(frame, id, x, y, z, brightness, time_on);
 
         int actualFrame = logger.getFrame().get(0);
         int actualId = logger.getId().get(0);
@@ -72,6 +73,7 @@ public class FrameLoggerTest {
         double actualY = logger.getY().get(0);
         double actualZ = logger.getZ().get(0);
         double actualBrightness = logger.getBrightness().get(0);
+        double actualTimeOn = logger.getTimeOn().get(0);
 
         assertEquals(frame, actualFrame);
         assertEquals(id, actualId);
@@ -79,6 +81,7 @@ public class FrameLoggerTest {
         assertEquals(y, actualY, 0.001);
         assertEquals(z, actualZ, 0.001);
         assertEquals(brightness, actualBrightness, 0.001);
+        assertEquals(time_on, actualTimeOn, 0.001);
     }
 
     /**
@@ -89,7 +92,7 @@ public class FrameLoggerTest {
         // Give the logger some initial state
         logger.setFilename("textLogFile.txt");
         logger.setPerformLogging(true);
-        logger.logFrame(1, 1, 10.0, 0.4, 0.8, 0.9);
+        logger.logFrame(1, 1, 10.0, 0.4, 0.8, 0.9, 0.2);
 
         assertTrue("textLogFile.txt".equals(logger.getFilename()));
         assertEquals(true, logger.getPerformLogging());
@@ -106,6 +109,7 @@ public class FrameLoggerTest {
         assertEquals(0.0, logger.getY().size(), 0.001);
         assertEquals(0.0, logger.getZ().size(), 0.001);
         assertEquals(0.0, logger.getBrightness().size(), 0.001);
+        assertEquals(0.0, logger.getTimeOn().size(), 0.001);
     }
     
         /**
@@ -119,8 +123,8 @@ public class FrameLoggerTest {
         logger.setPerformLogging(true);
         
         // Add some data to the logger
-        this.logger.logFrame(1, 1, 10.0, 5.0, 1.0, 0.8);
-        this.logger.logFrame(2, 5, 20.0, 5.0, 1.1, 0.6);
+        this.logger.logFrame(1, 1, 10.0, 5.0, 1.0, 0.8, 0.2);
+        this.logger.logFrame(2, 5, 20.0, 5.0, 1.1, 0.6, 0.3);
         
         // Critical test
         logger.saveLogFile();
@@ -133,9 +137,9 @@ public class FrameLoggerTest {
             String line2 = bufferedReader.readLine();
             String line3 = bufferedReader.readLine();
             
-            assertTrue(line1.equals("frame,id,x,y,z,brightness"));
-            assertTrue(line2.equals("1,1,10.0000,5.0000,1.0000,0.8000"));
-            assertTrue(line3.equals("2,5,20.0000,5.0000,1.1000,0.6000"));
+            assertTrue(line1.equals("frame,id,x,y,z,brightness,time_on"));
+            assertTrue(line2.equals("1,1,10.0000,5.0000,1.0000,0.8000,0.2000"));
+            assertTrue(line3.equals("2,5,20.0000,5.0000,1.1000,0.6000,0.3000"));
         } catch (IOException e)
         {
             throw e;

--- a/test/ch/epfl/leb/sass/simulator/loggers/FrameLoggerTest.java
+++ b/test/ch/epfl/leb/sass/simulator/loggers/FrameLoggerTest.java
@@ -60,25 +60,25 @@ public class FrameLoggerTest {
         double x = 2.3;
         double y = 2.5;
         double z = 0.7;
-        double time_on = 0.8;
+        double brightness = 0.8;
         logger.setPerformLogging(true);
 
         // Method call to test is here.
-        logger.logFrame(frame, id, x, y, z, time_on);
+        logger.logFrame(frame, id, x, y, z, brightness);
 
         int actualFrame = logger.getFrame().get(0);
         int actualId = logger.getId().get(0);
         double actualX = logger.getX().get(0);
         double actualY = logger.getY().get(0);
         double actualZ = logger.getZ().get(0);
-        double actualTimeOn = logger.getTimeOn().get(0);
+        double actualBrightness = logger.getBrightness().get(0);
 
         assertEquals(frame, actualFrame);
         assertEquals(id, actualId);
         assertEquals(x, actualX, 0.001);
         assertEquals(y, actualY, 0.001);
         assertEquals(z, actualZ, 0.001);
-        assertEquals(time_on, actualTimeOn, 0.001);
+        assertEquals(brightness, actualBrightness, 0.001);
     }
 
     /**
@@ -105,7 +105,7 @@ public class FrameLoggerTest {
         assertEquals(0.0, logger.getX().size(), 0.001);
         assertEquals(0.0, logger.getY().size(), 0.001);
         assertEquals(0.0, logger.getZ().size(), 0.001);
-        assertEquals(0.0, logger.getTimeOn().size(), 0.001);
+        assertEquals(0.0, logger.getBrightness().size(), 0.001);
     }
     
         /**
@@ -133,7 +133,7 @@ public class FrameLoggerTest {
             String line2 = bufferedReader.readLine();
             String line3 = bufferedReader.readLine();
             
-            assertTrue(line1.equals("frame,id,x,y,z,time_on"));
+            assertTrue(line1.equals("frame,id,x,y,z,brightness"));
             assertTrue(line2.equals("1,1,10.0000,5.0000,1.0000,0.8000"));
             assertTrue(line3.equals("2,5,20.0000,5.0000,1.1000,0.6000"));
         } catch (IOException e)


### PR DESCRIPTION
Sorry to be modifying this again. Using the brightness (the number of photons emmited by the fluorophore during the frame) is a better tool than the time_on to know when a fluorophore is visible on the frame.