### PR TITLE
Added access to all simulation parameters from the GUI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Contains [ALICA v0.2.4]
 ### Fixed
 - Fixed a cropping issue with the self-tuning PI controller dialog on
   Linux.
+- The `GibsonLanniPSF` cache is now erased everytime a new builder is
+  created for this PSF type. This prevents caching calculations done
+  for previous simulations.
+- The Save... button in the Initialize Simulation window is now
+  properly displayed as a Save dialog.
 
 ## [v0.5.1]
 

--- a/src/ch/epfl/leb/sass/ijplugin/InitializeSimulation.form
+++ b/src/ch/epfl/leb/sass/ijplugin/InitializeSimulation.form
@@ -38,27 +38,28 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="psfParentPanel" max="32767" attributes="0"/>
                   <Component id="jPanel2" max="32767" attributes="0"/>
-                  <Component id="jPanel3" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                  <Component id="jPanel4" alignment="0" max="32767" attributes="0"/>
-                  <Component id="jPanel5" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jPanel4" max="32767" attributes="0"/>
                   <Component id="jPanel6" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jPanel3" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jPanel5" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                  <Component id="jPanel8" max="32767" attributes="0"/>
-                  <Component id="jPanel7" max="32767" attributes="0"/>
-                  <Component id="jPanel9" max="32767" attributes="0"/>
+                  <Component id="jPanel9" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jPanel8" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jPanel7" alignment="0" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
-              <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                  <Component id="panel6" max="32767" attributes="0"/>
-                  <Component id="jPanel1" max="32767" attributes="0"/>
+              <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="panel6" min="-2" max="-2" attributes="0"/>
+                  <Component id="jPanel1" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="19" max="-2" attributes="0"/>
+              <EmptySpace pref="43" max="32767" attributes="0"/>
           </Group>
           <Group type="102" alignment="1" attributes="0">
               <EmptySpace max="32767" attributes="0"/>
@@ -67,7 +68,7 @@
               <Component id="openButton" linkSize="12" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="saveButton" linkSize="12" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" pref="441" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="529" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -77,26 +78,29 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" attributes="0">
-                              <Component id="jPanel7" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jPanel8" min="-2" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="jPanel2" alignment="0" max="32767" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="jPanel4" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace max="32767" attributes="0"/>
+                              <Component id="jPanel5" min="-2" max="-2" attributes="0"/>
                           </Group>
-                          <Group type="103" alignment="0" groupAlignment="1" max="-2" attributes="0">
-                              <Component id="jPanel2" alignment="0" max="32767" attributes="0"/>
-                              <Group type="102" alignment="0" attributes="0">
-                                  <Component id="jPanel4" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="jPanel5" min="-2" max="-2" attributes="0"/>
+                          <Component id="jPanel7" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                          <Component id="psfParentPanel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="jPanel3" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jPanel8" alignment="0" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="jPanel9" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jPanel6" max="32767" attributes="0"/>
                               </Group>
                           </Group>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="1" max="-2" attributes="0">
-                          <Component id="jPanel6" alignment="0" max="32767" attributes="0"/>
-                          <Component id="jPanel9" alignment="0" max="32767" attributes="0"/>
-                          <Component id="jPanel3" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                   <Group type="102" attributes="0">
@@ -203,7 +207,7 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="1" attributes="0">
-                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          <EmptySpace min="0" pref="10" max="32767" attributes="0"/>
                           <Component id="controller_panel" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <Group type="102" attributes="0">
@@ -347,53 +351,29 @@
                       <Component id="jLabel10" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel9" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraSizeX" linkSize="1" min="-2" pref="70" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel14" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraSizeY" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel15" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraReadoutNoise" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel16" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraDarkCurrent" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel17" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraQuantumEfficiency" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel18" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraAduPerElectron" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel19" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraEmGain" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel20" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraBaseline" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel21" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="cameraPixelSize" linkSize="1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel22" min="-2" max="-2" attributes="0"/>
-                      </Group>
+                      <Component id="cameraSizeX" linkSize="1" alignment="0" min="-2" pref="70" max="-2" attributes="0"/>
+                      <Component id="cameraSizeY" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraReadoutNoise" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraDarkCurrent" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraQuantumEfficiency" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraAduPerElectron" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraEmGain" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraBaseline" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="cameraPixelSize" linkSize="1" alignment="0" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="jLabel17" alignment="1" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel14" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel15" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel16" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel18" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel19" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel20" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel21" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel22" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
               </Group>
@@ -554,9 +534,6 @@
             <Property name="horizontalAlignment" type="int" value="4"/>
             <Property name="text" type="java.lang.String" value="100"/>
           </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cameraBaselineActionPerformed"/>
-          </Events>
         </Component>
         <Component class="javax.swing.JTextField" name="cameraPixelSize">
           <Properties>
@@ -1053,33 +1030,67 @@
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="emittersRandomButton" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="emittersGridButton" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="emittersCsvButton" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Group type="102" attributes="0">
-                          <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="jSeparator2" max="32767" attributes="0"/>
                               <Group type="102" attributes="0">
                                   <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                                      <Group type="102" alignment="1" attributes="0">
-                                          <Component id="jLabel45" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace max="32767" attributes="0"/>
-                                          <Component id="emittersRandomNumber" linkSize="13" min="-2" pref="54" max="-2" attributes="0"/>
+                                      <Component id="emittersRandomButton" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      <Component id="emittersGridButton" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      <Group type="102" attributes="0">
+                                          <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
+                                          <Group type="103" groupAlignment="0" attributes="0">
+                                              <Group type="102" attributes="0">
+                                                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                                                      <Group type="102" alignment="1" attributes="0">
+                                                          <Component id="jLabel45" min="-2" max="-2" attributes="0"/>
+                                                          <EmptySpace max="32767" attributes="0"/>
+                                                          <Component id="emittersRandomNumber" linkSize="13" min="-2" pref="54" max="-2" attributes="0"/>
+                                                      </Group>
+                                                      <Group type="102" alignment="1" attributes="0">
+                                                          <Component id="jLabel46" min="-2" max="-2" attributes="0"/>
+                                                          <EmptySpace max="32767" attributes="0"/>
+                                                          <Component id="emittersGridSpacing" linkSize="13" min="-2" max="-2" attributes="0"/>
+                                                      </Group>
+                                                  </Group>
+                                                  <EmptySpace max="-2" attributes="0"/>
+                                                  <Component id="jLabel47" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <Component id="emittersChooseFile" min="-2" pref="151" max="-2" attributes="0"/>
+                                          </Group>
                                       </Group>
-                                      <Group type="102" alignment="1" attributes="0">
-                                          <Component id="jLabel46" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace max="32767" attributes="0"/>
-                                          <Component id="emittersGridSpacing" linkSize="13" min="-2" max="-2" attributes="0"/>
-                                      </Group>
+                                      <Component id="emitters3DCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      <Component id="emittersCsvButton" alignment="0" max="32767" attributes="0"/>
                                   </Group>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="jLabel47" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                               </Group>
-                              <Component id="emittersChooseFile" min="-2" pref="151" max="-2" attributes="0"/>
                           </Group>
+                          <EmptySpace max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Group type="102" alignment="1" attributes="0">
+                                  <Component id="jLabel97" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" alignment="0" attributes="0">
+                                  <Component id="jLabel96" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
+                              </Group>
+                          </Group>
+                          <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                              <Component id="emitters3DMinZ" pref="54" max="32767" attributes="0"/>
+                              <Component id="emitters3DMaxZ" max="32767" attributes="0"/>
+                          </Group>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="jLabel98" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="jLabel99" alignment="1" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <EmptySpace max="32767" attributes="0"/>
                       </Group>
                   </Group>
-                  <EmptySpace max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -1103,9 +1114,25 @@
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="emittersCsvButton" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
                   <Component id="emittersChooseFile" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
+                  <Component id="jSeparator2" min="-2" pref="10" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="emitters3DCheckBox" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="jLabel96" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="emitters3DMinZ" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel98" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="jLabel97" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="emitters3DMaxZ" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel99" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace pref="15" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -1180,6 +1207,50 @@
         <Component class="javax.swing.JLabel" name="jLabel47">
           <Properties>
             <Property name="text" type="java.lang.String" value="pixels"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JSeparator" name="jSeparator2">
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="emitters3DCheckBox">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="3D"/>
+          </Properties>
+          <Events>
+            <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="emitters3DCheckBoxItemStateChanged"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel96">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Min. z-position"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel97">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Max. z-position"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="emitters3DMinZ">
+          <Properties>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="text" type="java.lang.String" value="0"/>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="emitters3DMaxZ">
+          <Properties>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="text" type="java.lang.String" value="2"/>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel98">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel99">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="&#xb5;m"/>
           </Properties>
         </Component>
       </SubComponents>
@@ -1287,7 +1358,6 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="backgroundUniformButton" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="backgroundTifButton" alignment="0" min="-2" pref="101" max="-2" attributes="0"/>
                       <Component id="backgroundRandomButton" min="-2" max="-2" attributes="0"/>
                       <Group type="102" attributes="0">
                           <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
@@ -1332,8 +1402,9 @@
                               </Group>
                           </Group>
                       </Group>
+                      <Component id="backgroundTifButton" alignment="0" min="-2" pref="158" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace min="37" pref="131" max="32767" attributes="0"/>
+                  <EmptySpace min="37" pref="132" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -1466,7 +1537,7 @@
         <Component class="javax.swing.JTextField" name="backgroundRandomFeatureSize">
           <Properties>
             <Property name="horizontalAlignment" type="int" value="4"/>
-            <Property name="text" type="java.lang.String" value="10"/>
+            <Property name="text" type="java.lang.String" value="50"/>
             <Property name="enabled" type="boolean" value="false"/>
           </Properties>
         </Component>
@@ -1537,5 +1608,667 @@
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="openButtonActionPerformed"/>
       </Events>
     </Component>
+    <Container class="javax.swing.JPanel" name="psfParentPanel">
+      <Properties>
+        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+          <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
+            <TitledBorder title="PSF"/>
+          </Border>
+        </Property>
+      </Properties>
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="1" attributes="0">
+                      <Component id="psfCardPanel" max="32767" attributes="0"/>
+                      <Component id="psfComboBox" alignment="0" max="32767" attributes="0"/>
+                      <Component id="jSeparator1" alignment="0" max="32767" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="psfComboBox" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="jSeparator1" min="-2" pref="6" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="psfCardPanel" pref="314" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JComboBox" name="psfComboBox">
+          <Properties>
+            <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+              <StringArray count="3">
+                <StringItem index="0" value="Gaussian 2D"/>
+                <StringItem index="1" value="Gaussian 3D"/>
+                <StringItem index="2" value="Gibson-Lanni"/>
+              </StringArray>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="psfComboBoxItemStateChanged"/>
+          </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+          </AuxValues>
+        </Component>
+        <Component class="javax.swing.JSeparator" name="jSeparator1">
+        </Component>
+        <Container class="javax.swing.JPanel" name="psfCardPanel">
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignCardLayout"/>
+          <SubComponents>
+            <Container class="javax.swing.JPanel" name="psfGaussian2DCard">
+              <Properties>
+                <Property name="name" type="java.lang.String" value="Gaussian 2D" noResource="true"/>
+              </Properties>
+              <AccessibilityProperties>
+                <Property name="AccessibleContext.accessibleName" type="java.lang.String" value=""/>
+                <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" value=""/>
+              </AccessibilityProperties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignCardLayout" value="org.netbeans.modules.form.compat2.layouts.DesignCardLayout$CardConstraintsDescription">
+                  <CardConstraints cardName="Gaussian 2D"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout>
+                <DimensionLayout dim="0">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="psfGaussian2DLabel" min="-2" pref="247" max="-2" attributes="0"/>
+                          <EmptySpace pref="127" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+                <DimensionLayout dim="1">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="psfGaussian2DLabel" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace pref="287" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+              </Layout>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="psfGaussian2DLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Nothing to configure."/>
+                  </Properties>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JPanel" name="psfGaussian3DCard">
+              <Properties>
+                <Property name="name" type="java.lang.String" value="Gaussian 3D" noResource="true"/>
+              </Properties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignCardLayout" value="org.netbeans.modules.form.compat2.layouts.DesignCardLayout$CardConstraintsDescription">
+                  <CardConstraints cardName="Gaussian 3D"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout>
+                <DimensionLayout dim="0">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="psfGaussian3DLabel" min="-2" pref="216" max="-2" attributes="0"/>
+                          <EmptySpace pref="158" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+                <DimensionLayout dim="1">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="psfGaussian3DLabel" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace pref="287" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+              </Layout>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="psfGaussian3DLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Nothing to configure."/>
+                  </Properties>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JScrollPane" name="psfGibsonLanniCard">
+              <Properties>
+                <Property name="name" type="java.lang.String" value="Gibson-Lanni" noResource="true"/>
+              </Properties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignCardLayout" value="org.netbeans.modules.form.compat2.layouts.DesignCardLayout$CardConstraintsDescription">
+                  <CardConstraints cardName="Gibson-Lanni"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+              <SubComponents>
+                <Container class="javax.swing.JPanel" name="psfGibsonLanniPanel">
+
+                  <Layout>
+                    <DimensionLayout dim="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Group type="102" alignment="0" attributes="0">
+                              <EmptySpace min="-2" max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                                  <Group type="102" attributes="0">
+                                      <Component id="jLabel62" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNumBasis" linkSize="15" min="-2" pref="60" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel63" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNumSamples" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel64" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glOversampling" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel65" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glSizeX" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel66" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glSizeY" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel67" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNs" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel68" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNg0" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel78" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glMaxRadius" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel77" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glSolver" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel76" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glResPsfAxial" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel75" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glResPsf" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel74" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glTg" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel73" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glTg0" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel69" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNg" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel70" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNi0" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel71" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glNi" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel72" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="32767" attributes="0"/>
+                                      <Component id="glTi0" linkSize="15" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="jLabel79" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel80" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel81" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel82" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel83" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel84" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel85" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel86" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel87" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel88" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel89" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel90" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel91" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel92" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel93" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel94" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel95" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="32767" attributes="0"/>
+                          </Group>
+                      </Group>
+                    </DimensionLayout>
+                    <DimensionLayout dim="1">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Group type="102" alignment="0" attributes="0">
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel62" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNumBasis" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel79" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel63" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNumSamples" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel80" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel64" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glOversampling" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel81" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel65" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glSizeX" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel82" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel66" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glSizeY" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel83" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel67" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNs" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel84" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel68" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNg0" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel85" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel69" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNg" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel86" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel70" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNi0" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel87" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel71" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glNi" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel88" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel72" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glTi0" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel89" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel73" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glTg0" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel90" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel74" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glTg" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel91" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel75" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glResPsf" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel92" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel76" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glResPsfAxial" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel93" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel77" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glSolver" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel94" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="3" attributes="0">
+                                  <Component id="jLabel78" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="glMaxRadius" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel95" alignment="3" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace pref="24" max="32767" attributes="0"/>
+                          </Group>
+                      </Group>
+                    </DimensionLayout>
+                  </Layout>
+                  <SubComponents>
+                    <Component class="javax.swing.JLabel" name="jLabel62">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Number of Bessels"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel63">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Number of samples"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel64">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Oversampling"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel65">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Grid size, x"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel66">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Grid size, y"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel67">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Sample refractive index (n)"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel68">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Coverslip, design n"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel69">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Coverslip, actual n"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel70">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Immersion medium, design n"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel71">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Immersion medium, actual n"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel72">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Immersion medium, design thickness"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel73">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Coverslip, design thickness"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel74">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Coverslip, actual thickness"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel75">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Resolution"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel76">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Axial resolution"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel77">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Solver"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel78">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="Maximum radius"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNumBasis">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="100"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNumSamples">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1000"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glOversampling">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="2"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glSizeX">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1024"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glSizeY">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1024"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNs">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1.33"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNg0">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1.5"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNg">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1.5"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNi0">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1.5"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glNi">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="1.5"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glTi0">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="150"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glTg0">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="170"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glTg">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="170"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glResPsf">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="0.0215"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glResPsfAxial">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="0.005"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glSolver">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="svd"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JTextField" name="glMaxRadius">
+                      <Properties>
+                        <Property name="horizontalAlignment" type="int" value="4"/>
+                        <Property name="text" type="java.lang.String" value="15"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel79">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel80">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel81">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel82">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="pixels"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel83">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="pixels"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel84">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel85">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel86">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel87">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel88">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="--"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel89">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel90">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel91">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel92">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel93">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="&#xb5;m"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel94">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="svd or qrd"/>
+                      </Properties>
+                    </Component>
+                    <Component class="javax.swing.JLabel" name="jLabel95">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" value="pixels"/>
+                      </Properties>
+                    </Component>
+                  </SubComponents>
+                </Container>
+              </SubComponents>
+            </Container>
+          </SubComponents>
+        </Container>
+      </SubComponents>
+    </Container>
   </SubComponents>
 </Form>

--- a/src/ch/epfl/leb/sass/ijplugin/InitializeSimulation.java
+++ b/src/ch/epfl/leb/sass/ijplugin/InitializeSimulation.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.ButtonModel;
+import java.awt.CardLayout;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 /**
@@ -200,6 +201,14 @@ public class InitializeSimulation extends java.awt.Dialog {
         emittersGridSpacing = new javax.swing.JTextField();
         jLabel46 = new javax.swing.JLabel();
         jLabel47 = new javax.swing.JLabel();
+        jSeparator2 = new javax.swing.JSeparator();
+        emitters3DCheckBox = new javax.swing.JCheckBox();
+        jLabel96 = new javax.swing.JLabel();
+        jLabel97 = new javax.swing.JLabel();
+        emitters3DMinZ = new javax.swing.JTextField();
+        emitters3DMaxZ = new javax.swing.JTextField();
+        jLabel98 = new javax.swing.JLabel();
+        jLabel99 = new javax.swing.JLabel();
         jPanel8 = new javax.swing.JPanel();
         jLabel48 = new javax.swing.JLabel();
         jLabel49 = new javax.swing.JLabel();
@@ -230,6 +239,67 @@ public class InitializeSimulation extends java.awt.Dialog {
         initializeSimulation = new javax.swing.JButton();
         saveButton = new javax.swing.JButton();
         openButton = new javax.swing.JButton();
+        psfParentPanel = new javax.swing.JPanel();
+        psfComboBox = new javax.swing.JComboBox<>();
+        jSeparator1 = new javax.swing.JSeparator();
+        psfCardPanel = new javax.swing.JPanel();
+        psfGaussian2DCard = new javax.swing.JPanel();
+        psfGaussian2DLabel = new javax.swing.JLabel();
+        psfGaussian3DCard = new javax.swing.JPanel();
+        psfGaussian3DLabel = new javax.swing.JLabel();
+        psfGibsonLanniCard = new javax.swing.JScrollPane();
+        psfGibsonLanniPanel = new javax.swing.JPanel();
+        jLabel62 = new javax.swing.JLabel();
+        jLabel63 = new javax.swing.JLabel();
+        jLabel64 = new javax.swing.JLabel();
+        jLabel65 = new javax.swing.JLabel();
+        jLabel66 = new javax.swing.JLabel();
+        jLabel67 = new javax.swing.JLabel();
+        jLabel68 = new javax.swing.JLabel();
+        jLabel69 = new javax.swing.JLabel();
+        jLabel70 = new javax.swing.JLabel();
+        jLabel71 = new javax.swing.JLabel();
+        jLabel72 = new javax.swing.JLabel();
+        jLabel73 = new javax.swing.JLabel();
+        jLabel74 = new javax.swing.JLabel();
+        jLabel75 = new javax.swing.JLabel();
+        jLabel76 = new javax.swing.JLabel();
+        jLabel77 = new javax.swing.JLabel();
+        jLabel78 = new javax.swing.JLabel();
+        glNumBasis = new javax.swing.JTextField();
+        glNumSamples = new javax.swing.JTextField();
+        glOversampling = new javax.swing.JTextField();
+        glSizeX = new javax.swing.JTextField();
+        glSizeY = new javax.swing.JTextField();
+        glNs = new javax.swing.JTextField();
+        glNg0 = new javax.swing.JTextField();
+        glNg = new javax.swing.JTextField();
+        glNi0 = new javax.swing.JTextField();
+        glNi = new javax.swing.JTextField();
+        glTi0 = new javax.swing.JTextField();
+        glTg0 = new javax.swing.JTextField();
+        glTg = new javax.swing.JTextField();
+        glResPsf = new javax.swing.JTextField();
+        glResPsfAxial = new javax.swing.JTextField();
+        glSolver = new javax.swing.JTextField();
+        glMaxRadius = new javax.swing.JTextField();
+        jLabel79 = new javax.swing.JLabel();
+        jLabel80 = new javax.swing.JLabel();
+        jLabel81 = new javax.swing.JLabel();
+        jLabel82 = new javax.swing.JLabel();
+        jLabel83 = new javax.swing.JLabel();
+        jLabel84 = new javax.swing.JLabel();
+        jLabel85 = new javax.swing.JLabel();
+        jLabel86 = new javax.swing.JLabel();
+        jLabel87 = new javax.swing.JLabel();
+        jLabel88 = new javax.swing.JLabel();
+        jLabel89 = new javax.swing.JLabel();
+        jLabel90 = new javax.swing.JLabel();
+        jLabel91 = new javax.swing.JLabel();
+        jLabel92 = new javax.swing.JLabel();
+        jLabel93 = new javax.swing.JLabel();
+        jLabel94 = new javax.swing.JLabel();
+        jLabel95 = new javax.swing.JLabel();
 
         setBackground(javax.swing.UIManager.getDefaults().getColor("Button.background"));
         setResizable(false);
@@ -336,7 +406,7 @@ public class InitializeSimulation extends java.awt.Dialog {
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
-                        .addGap(0, 0, Short.MAX_VALUE)
+                        .addGap(0, 10, Short.MAX_VALUE)
                         .addComponent(controller_panel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -418,11 +488,6 @@ public class InitializeSimulation extends java.awt.Dialog {
 
         cameraBaseline.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
         cameraBaseline.setText("100");
-        cameraBaseline.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                cameraBaselineActionPerformed(evt);
-            }
-        });
 
         cameraPixelSize.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
         cameraPixelSize.setText("6.5");
@@ -461,44 +526,28 @@ public class InitializeSimulation extends java.awt.Dialog {
                     .addComponent(jLabel13)
                     .addComponent(jLabel10)
                     .addComponent(jLabel9))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraSizeX, javax.swing.GroupLayout.PREFERRED_SIZE, 70, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel14))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraSizeY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel15))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraReadoutNoise, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel16))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraDarkCurrent, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel17))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraQuantumEfficiency, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel18))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraAduPerElectron, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel19))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraEmGain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel20))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraBaseline, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel21))
-                    .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addComponent(cameraPixelSize, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel22)))
+                    .addComponent(cameraSizeX, javax.swing.GroupLayout.PREFERRED_SIZE, 70, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraSizeY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraReadoutNoise, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraDarkCurrent, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraQuantumEfficiency, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraAduPerElectron, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraEmGain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraBaseline, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cameraPixelSize, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel17, javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(jLabel14)
+                    .addComponent(jLabel15)
+                    .addComponent(jLabel16)
+                    .addComponent(jLabel18)
+                    .addComponent(jLabel19)
+                    .addComponent(jLabel20)
+                    .addComponent(jLabel21)
+                    .addComponent(jLabel22))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -867,6 +916,29 @@ public class InitializeSimulation extends java.awt.Dialog {
 
         jLabel47.setText("pixels");
 
+        emitters3DCheckBox.setText("3D");
+        emitters3DCheckBox.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                emitters3DCheckBoxItemStateChanged(evt);
+            }
+        });
+
+        jLabel96.setText("Min. z-position");
+
+        jLabel97.setText("Max. z-position");
+
+        emitters3DMinZ.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        emitters3DMinZ.setText("0");
+        emitters3DMinZ.setEnabled(false);
+
+        emitters3DMaxZ.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        emitters3DMaxZ.setText("2");
+        emitters3DMaxZ.setEnabled(false);
+
+        jLabel98.setText("µm");
+
+        jLabel99.setText("µm");
+
         javax.swing.GroupLayout jPanel7Layout = new javax.swing.GroupLayout(jPanel7);
         jPanel7.setLayout(jPanel7Layout);
         jPanel7Layout.setHorizontalGroup(
@@ -874,26 +946,50 @@ public class InitializeSimulation extends java.awt.Dialog {
             .addGroup(jPanel7Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(emittersRandomButton)
-                    .addComponent(emittersGridButton)
-                    .addComponent(emittersCsvButton)
+                    .addGroup(jPanel7Layout.createSequentialGroup()
+                        .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jSeparator2)
+                            .addGroup(jPanel7Layout.createSequentialGroup()
+                                .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                    .addComponent(emittersRandomButton)
+                                    .addComponent(emittersGridButton)
+                                    .addGroup(jPanel7Layout.createSequentialGroup()
+                                        .addGap(21, 21, 21)
+                                        .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                            .addGroup(jPanel7Layout.createSequentialGroup()
+                                                .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel7Layout.createSequentialGroup()
+                                                        .addComponent(jLabel45)
+                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                        .addComponent(emittersRandomNumber, javax.swing.GroupLayout.PREFERRED_SIZE, 54, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel7Layout.createSequentialGroup()
+                                                        .addComponent(jLabel46)
+                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                        .addComponent(emittersGridSpacing, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(jLabel47))
+                                            .addComponent(emittersChooseFile, javax.swing.GroupLayout.PREFERRED_SIZE, 151, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                    .addComponent(emitters3DCheckBox)
+                                    .addComponent(emittersCsvButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addGap(0, 0, Short.MAX_VALUE)))
+                        .addContainerGap())
                     .addGroup(jPanel7Layout.createSequentialGroup()
                         .addGap(21, 21, 21)
                         .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel7Layout.createSequentialGroup()
+                                .addComponent(jLabel97)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED))
                             .addGroup(jPanel7Layout.createSequentialGroup()
-                                .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel7Layout.createSequentialGroup()
-                                        .addComponent(jLabel45)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                        .addComponent(emittersRandomNumber, javax.swing.GroupLayout.PREFERRED_SIZE, 54, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel7Layout.createSequentialGroup()
-                                        .addComponent(jLabel46)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                        .addComponent(emittersGridSpacing, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jLabel47))
-                            .addComponent(emittersChooseFile, javax.swing.GroupLayout.PREFERRED_SIZE, 151, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addComponent(jLabel96)
+                                .addGap(13, 13, 13)))
+                        .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                            .addComponent(emitters3DMinZ, javax.swing.GroupLayout.DEFAULT_SIZE, 54, Short.MAX_VALUE)
+                            .addComponent(emitters3DMaxZ))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jLabel98)
+                            .addComponent(jLabel99, javax.swing.GroupLayout.Alignment.TRAILING))
+                        .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
         );
 
         jPanel7Layout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {emittersGridSpacing, emittersRandomNumber});
@@ -916,9 +1012,23 @@ public class InitializeSimulation extends java.awt.Dialog {
                     .addComponent(jLabel47))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(emittersCsvButton)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(emittersChooseFile)
-                .addContainerGap())
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jSeparator2, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(emitters3DCheckBox)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel96)
+                    .addComponent(emitters3DMinZ, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel98))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel97)
+                    .addComponent(emitters3DMaxZ, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel99))
+                .addContainerGap(15, Short.MAX_VALUE))
         );
 
         jPanel8.setBorder(javax.swing.BorderFactory.createTitledBorder("Fiducials"));
@@ -1023,7 +1133,7 @@ public class InitializeSimulation extends java.awt.Dialog {
         jLabel57.setText("Seed");
 
         backgroundRandomFeatureSize.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
-        backgroundRandomFeatureSize.setText("10");
+        backgroundRandomFeatureSize.setText("50");
         backgroundRandomFeatureSize.setEnabled(false);
 
         backgroundRandomMinValue.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
@@ -1054,7 +1164,6 @@ public class InitializeSimulation extends java.awt.Dialog {
                 .addContainerGap()
                 .addGroup(jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(backgroundUniformButton)
-                    .addComponent(backgroundTifButton, javax.swing.GroupLayout.PREFERRED_SIZE, 101, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(backgroundRandomButton)
                     .addGroup(jPanel9Layout.createSequentialGroup()
                         .addGap(21, 21, 21)
@@ -1088,8 +1197,9 @@ public class InitializeSimulation extends java.awt.Dialog {
                                     .addComponent(jLabel59)
                                     .addComponent(jLabel60)
                                     .addComponent(jLabel61)
-                                    .addComponent(jLabel53, javax.swing.GroupLayout.Alignment.TRAILING))))))
-                .addGap(37, 131, Short.MAX_VALUE))
+                                    .addComponent(jLabel53, javax.swing.GroupLayout.Alignment.TRAILING)))))
+                    .addComponent(backgroundTifButton, javax.swing.GroupLayout.PREFERRED_SIZE, 158, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addGap(37, 132, Short.MAX_VALUE))
         );
 
         jPanel9Layout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {backgroundRandomFeatureSize, backgroundRandomMaxValue, backgroundRandomMinValue, backgroundRandomSeed, backgroundUniformSignal});
@@ -1154,6 +1264,404 @@ public class InitializeSimulation extends java.awt.Dialog {
             }
         });
 
+        psfParentPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("PSF"));
+
+        psfComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Gaussian 2D", "Gaussian 3D", "Gibson-Lanni" }));
+        psfComboBox.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                psfComboBoxItemStateChanged(evt);
+            }
+        });
+
+        psfCardPanel.setLayout(new java.awt.CardLayout());
+
+        psfGaussian2DCard.setName("Gaussian 2D"); // NOI18N
+
+        psfGaussian2DLabel.setText("Nothing to configure.");
+
+        javax.swing.GroupLayout psfGaussian2DCardLayout = new javax.swing.GroupLayout(psfGaussian2DCard);
+        psfGaussian2DCard.setLayout(psfGaussian2DCardLayout);
+        psfGaussian2DCardLayout.setHorizontalGroup(
+            psfGaussian2DCardLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGaussian2DCardLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(psfGaussian2DLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 247, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(127, Short.MAX_VALUE))
+        );
+        psfGaussian2DCardLayout.setVerticalGroup(
+            psfGaussian2DCardLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGaussian2DCardLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(psfGaussian2DLabel)
+                .addContainerGap(287, Short.MAX_VALUE))
+        );
+
+        psfCardPanel.add(psfGaussian2DCard, "Gaussian 2D");
+        psfGaussian2DCard.getAccessibleContext().setAccessibleName("");
+        psfGaussian2DCard.getAccessibleContext().setAccessibleDescription("");
+
+        psfGaussian3DCard.setName("Gaussian 3D"); // NOI18N
+
+        psfGaussian3DLabel.setText("Nothing to configure.");
+
+        javax.swing.GroupLayout psfGaussian3DCardLayout = new javax.swing.GroupLayout(psfGaussian3DCard);
+        psfGaussian3DCard.setLayout(psfGaussian3DCardLayout);
+        psfGaussian3DCardLayout.setHorizontalGroup(
+            psfGaussian3DCardLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGaussian3DCardLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(psfGaussian3DLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 216, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(158, Short.MAX_VALUE))
+        );
+        psfGaussian3DCardLayout.setVerticalGroup(
+            psfGaussian3DCardLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGaussian3DCardLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(psfGaussian3DLabel)
+                .addContainerGap(287, Short.MAX_VALUE))
+        );
+
+        psfCardPanel.add(psfGaussian3DCard, "Gaussian 3D");
+
+        psfGibsonLanniCard.setName("Gibson-Lanni"); // NOI18N
+
+        jLabel62.setText("Number of Bessels");
+
+        jLabel63.setText("Number of samples");
+
+        jLabel64.setText("Oversampling");
+
+        jLabel65.setText("Grid size, x");
+
+        jLabel66.setText("Grid size, y");
+
+        jLabel67.setText("Sample refractive index (n)");
+
+        jLabel68.setText("Coverslip, design n");
+
+        jLabel69.setText("Coverslip, actual n");
+
+        jLabel70.setText("Immersion medium, design n");
+
+        jLabel71.setText("Immersion medium, actual n");
+
+        jLabel72.setText("Immersion medium, design thickness");
+
+        jLabel73.setText("Coverslip, design thickness");
+
+        jLabel74.setText("Coverslip, actual thickness");
+
+        jLabel75.setText("Resolution");
+
+        jLabel76.setText("Axial resolution");
+
+        jLabel77.setText("Solver");
+
+        jLabel78.setText("Maximum radius");
+
+        glNumBasis.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNumBasis.setText("100");
+
+        glNumSamples.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNumSamples.setText("1000");
+
+        glOversampling.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glOversampling.setText("2");
+
+        glSizeX.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glSizeX.setText("1024");
+
+        glSizeY.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glSizeY.setText("1024");
+
+        glNs.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNs.setText("1.33");
+
+        glNg0.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNg0.setText("1.5");
+
+        glNg.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNg.setText("1.5");
+
+        glNi0.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNi0.setText("1.5");
+
+        glNi.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glNi.setText("1.5");
+
+        glTi0.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glTi0.setText("150");
+
+        glTg0.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glTg0.setText("170");
+
+        glTg.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glTg.setText("170");
+
+        glResPsf.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glResPsf.setText("0.0215");
+
+        glResPsfAxial.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glResPsfAxial.setText("0.005");
+
+        glSolver.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glSolver.setText("svd");
+
+        glMaxRadius.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        glMaxRadius.setText("15");
+
+        jLabel79.setText("--");
+
+        jLabel80.setText("--");
+
+        jLabel81.setText("--");
+
+        jLabel82.setText("pixels");
+
+        jLabel83.setText("pixels");
+
+        jLabel84.setText("--");
+
+        jLabel85.setText("--");
+
+        jLabel86.setText("--");
+
+        jLabel87.setText("--");
+
+        jLabel88.setText("--");
+
+        jLabel89.setText("µm");
+
+        jLabel90.setText("µm");
+
+        jLabel91.setText("µm");
+
+        jLabel92.setText("µm");
+
+        jLabel93.setText("µm");
+
+        jLabel94.setText("svd or qrd");
+
+        jLabel95.setText("pixels");
+
+        javax.swing.GroupLayout psfGibsonLanniPanelLayout = new javax.swing.GroupLayout(psfGibsonLanniPanel);
+        psfGibsonLanniPanel.setLayout(psfGibsonLanniPanelLayout);
+        psfGibsonLanniPanelLayout.setHorizontalGroup(
+            psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel62)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNumBasis, javax.swing.GroupLayout.PREFERRED_SIZE, 60, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel63)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNumSamples, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel64)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glOversampling, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel65)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glSizeX, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel66)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glSizeY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel67)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNs, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel68)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNg0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel78)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glMaxRadius, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel77)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glSolver, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel76)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glResPsfAxial, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel75)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glResPsf, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel74)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glTg, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel73)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glTg0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel69)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNg, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel70)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNi0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel71)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glNi, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                        .addComponent(jLabel72)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(glTi0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel79)
+                    .addComponent(jLabel80)
+                    .addComponent(jLabel81)
+                    .addComponent(jLabel82)
+                    .addComponent(jLabel83)
+                    .addComponent(jLabel84)
+                    .addComponent(jLabel85)
+                    .addComponent(jLabel86)
+                    .addComponent(jLabel87)
+                    .addComponent(jLabel88)
+                    .addComponent(jLabel89)
+                    .addComponent(jLabel90)
+                    .addComponent(jLabel91)
+                    .addComponent(jLabel92)
+                    .addComponent(jLabel93)
+                    .addComponent(jLabel94)
+                    .addComponent(jLabel95))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+
+        psfGibsonLanniPanelLayout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {glMaxRadius, glNg, glNg0, glNi, glNi0, glNs, glNumBasis, glNumSamples, glOversampling, glResPsf, glResPsfAxial, glSizeX, glSizeY, glSolver, glTg, glTg0, glTi0});
+
+        psfGibsonLanniPanelLayout.setVerticalGroup(
+            psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfGibsonLanniPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel62)
+                    .addComponent(glNumBasis, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel79))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel63)
+                    .addComponent(glNumSamples, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel80))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel64)
+                    .addComponent(glOversampling, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel81))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel65)
+                    .addComponent(glSizeX, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel82))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel66)
+                    .addComponent(glSizeY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel83))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel67)
+                    .addComponent(glNs, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel84))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel68)
+                    .addComponent(glNg0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel85))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel69)
+                    .addComponent(glNg, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel86))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel70)
+                    .addComponent(glNi0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel87))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel71)
+                    .addComponent(glNi, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel88))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel72)
+                    .addComponent(glTi0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel89))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel73)
+                    .addComponent(glTg0, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel90))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel74)
+                    .addComponent(glTg, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel91))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel75)
+                    .addComponent(glResPsf, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel92))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel76)
+                    .addComponent(glResPsfAxial, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel93))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel77)
+                    .addComponent(glSolver, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel94))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(psfGibsonLanniPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel78)
+                    .addComponent(glMaxRadius, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel95))
+                .addContainerGap(24, Short.MAX_VALUE))
+        );
+
+        psfGibsonLanniCard.setViewportView(psfGibsonLanniPanel);
+
+        psfCardPanel.add(psfGibsonLanniCard, "Gibson-Lanni");
+
+        javax.swing.GroupLayout psfParentPanelLayout = new javax.swing.GroupLayout(psfParentPanel);
+        psfParentPanel.setLayout(psfParentPanelLayout);
+        psfParentPanelLayout.setHorizontalGroup(
+            psfParentPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, psfParentPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(psfParentPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(psfCardPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(psfComboBox, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jSeparator1, javax.swing.GroupLayout.Alignment.LEADING))
+                .addContainerGap())
+        );
+        psfParentPanelLayout.setVerticalGroup(
+            psfParentPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(psfParentPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(psfComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jSeparator1, javax.swing.GroupLayout.PREFERRED_SIZE, 6, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(psfCardPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 314, Short.MAX_VALUE)
+                .addContainerGap())
+        );
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -1161,23 +1669,24 @@ public class InitializeSimulation extends java.awt.Dialog {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                    .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(psfParentPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                     .addComponent(jPanel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel5, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(jPanel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jPanel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jPanel5, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(jPanel9, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(jPanel8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel9, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                    .addComponent(panel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addGap(19, 19, 19))
+                    .addComponent(jPanel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGap(13, 13, 13)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(panel6, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(43, Short.MAX_VALUE))
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(initializeSimulation)
@@ -1185,7 +1694,7 @@ public class InitializeSimulation extends java.awt.Dialog {
                 .addComponent(openButton)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(saveButton)
-                .addGap(441, 441, 441))
+                .addGap(529, 529, 529))
         );
 
         layout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {initializeSimulation, openButton, saveButton});
@@ -1196,22 +1705,24 @@ public class InitializeSimulation extends java.awt.Dialog {
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addGroup(layout.createSequentialGroup()
-                                .addComponent(jPanel7, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jPanel8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                                .addComponent(jPanel2, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                                    .addComponent(jPanel4, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                    .addComponent(jPanel5, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jPanel4, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addComponent(jPanel5, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(jPanel7, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(12, 12, 12)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                            .addComponent(jPanel6, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(jPanel9, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(jPanel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                            .addComponent(psfParentPanel, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(jPanel3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addComponent(jPanel8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(jPanel9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addComponent(jPanel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))))
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(panel6, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -1248,10 +1759,6 @@ public class InitializeSimulation extends java.awt.Dialog {
     private void fluorophoreTOffActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_fluorophoreTOffActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_fluorophoreTOffActionPerformed
-
-    private void cameraBaselineActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cameraBaselineActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_cameraBaselineActionPerformed
 
     private void backgroundChooseFileActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_backgroundChooseFileActionPerformed
         JFileChooser fc = new JFileChooser();
@@ -1333,6 +1840,9 @@ public class InitializeSimulation extends java.awt.Dialog {
         model.setEmittersRandomButtonText(emittersRandomButton.getText());
         model.setEmittersGridButtonText(emittersGridButton.getText());
         model.setEmittersCsvFileButtonText(emittersCsvButton.getText());
+        model.setEmitters3DCheckBoxEnabled(emitters3DCheckBox.isSelected());
+        model.setEmitters3DMinZ(Double.parseDouble(emitters3DMinZ.getText()));
+        model.setEmitters3DMaxZ(Double.parseDouble(emitters3DMaxZ.getText()));
         
         String selectedBackgroundButton = ButtonGroupUtils.getSelectedButtonText(this.backgroundButtons);
         model.setBackgroundCurrentSelection(selectedBackgroundButton);
@@ -1345,6 +1855,28 @@ public class InitializeSimulation extends java.awt.Dialog {
         model.setBackgroundUniformButtonText(backgroundUniformButton.getText());
         model.setBackgroundRandomButtonText(backgroundRandomButton.getText());
         model.setBackgroundTifFileButtonText(backgroundTifButton.getText());
+        
+        model.setPsfCurrentSelection(String.valueOf(psfComboBox.getSelectedItem()));
+        model.setPsfGaussian2dText(psfGaussian2DCard.getName());
+        model.setPsfGaussian3dText(psfGaussian3DCard.getName());
+        model.setPsfGibsonLanniNumBasis(Integer.parseInt(glNumBasis.getText()));
+        model.setPsfGibsonLanniNumSamples(Integer.parseInt(glNumSamples.getText()));
+        model.setPsfGibsonLanniOversampling(Integer.parseInt(glOversampling.getText()));
+        model.setPsfGibsonLanniSizeX(Integer.parseInt(glSizeX.getText()));
+        model.setPsfGibsonLanniSizeY(Integer.parseInt(glSizeY.getText()));
+        model.setPsfGibsonLanniNs(Double.parseDouble(glNs.getText()));
+        model.setPsfGibsonLanniNg0(Double.parseDouble(glNg0.getText()));
+        model.setPsfGibsonLanniNg(Double.parseDouble(glNg.getText()));
+        model.setPsfGibsonLanniNi0(Double.parseDouble(glNi0.getText()));
+        model.setPsfGibsonLanniNi(Double.parseDouble(glNi.getText()));
+        model.setPsfGibsonLanniTi0(Double.parseDouble(glTi0.getText()));
+        model.setPsfGibsonLanniTg0(Double.parseDouble(glTg0.getText()));
+        model.setPsfGibsonLanniTg(Double.parseDouble(glTg.getText()));
+        model.setPsfGibsonLanniResPsf(Double.parseDouble(glResPsf.getText()));
+        model.setPsfGibsonLanniResPsfAxial(Double.parseDouble(glResPsfAxial.getText()));
+        model.setPsfGibsonLanniSolver(glSolver.getText());
+        model.setPsfGibsonLanniMaxRadius(Integer.parseInt(glMaxRadius.getText()));
+        model.setPsfGibsonLanniText(psfGibsonLanniCard.getName());
     }
     
     /**
@@ -1383,6 +1915,9 @@ public class InitializeSimulation extends java.awt.Dialog {
         emittersGridSpacing.setText(String.valueOf(model.getEmittersGridSpacing()));
         emittersCsvFile = new File(model.getEmittersCsvFile());
         ButtonGroupUtils.selectButtonModelFromText(emittersButtons, model.getEmittersCurrentSelection());
+        emitters3DCheckBox.setSelected(model.getEmitters3DCheckBoxEnabled());
+        emitters3DMinZ.setText(String.valueOf(model.getEmitters3DMinZ()));
+        emitters3DMaxZ.setText(String.valueOf(model.getEmitters3DMaxZ()));
         
         backgroundUniformSignal.setText(String.valueOf(model.getBackgroundUniformSignal()));
         backgroundRandomFeatureSize.setText(String.valueOf(model.getBackgroundRandomFeatureSize()));
@@ -1391,6 +1926,26 @@ public class InitializeSimulation extends java.awt.Dialog {
         backgroundRandomSeed.setText(String.valueOf(model.getBackgroundRandomSeed()));
         backgroundTifFile = new File(model.getBackgroundTifFile());
         ButtonGroupUtils.selectButtonModelFromText(backgroundButtons, model.getBackgroundCurrentSelection());
+        
+        psfComboBox.setSelectedItem(model.getPsfCurrentSelection());
+        glNumBasis.setText(String.valueOf(model.getPsfGibsonLanniNumBasis()));
+        glNumSamples.setText(String.valueOf(model.getPsfGibsonLanniNumSamples()));
+        glOversampling.setText(String.valueOf(model.getPsfGibsonLanniOversampling()));
+        glSizeX.setText(String.valueOf(model.getPsfGibsonLanniSizeX()));
+        glSizeY.setText(String.valueOf(model.getPsfGibsonLanniSizeY()));
+        glNs.setText(String.valueOf(model.getPsfGibsonLanniNs()));
+        glNg0.setText(String.valueOf(model.getPsfGibsonLanniNg0()));
+        glNg.setText(String.valueOf(model.getPsfGibsonLanniNg()));
+        glNi0.setText(String.valueOf(model.getPsfGibsonLanniNi0()));
+        glNi.setText(String.valueOf(model.getPsfGibsonLanniNi()));
+        glTi0.setText(String.valueOf(model.getPsfGibsonLanniTi0()));
+        glTg0.setText(String.valueOf(model.getPsfGibsonLanniTg0()));
+        glTg.setText(String.valueOf(model.getPsfGibsonLanniTg()));
+        glResPsf.setText(String.valueOf(model.getPsfGibsonLanniResPsf()));
+        glResPsfAxial.setText(String.valueOf(model.getPsfGibsonLanniResPsfAxial()));
+        glSolver.setText(model.getPsfGibsonLanniSolver());
+        glMaxRadius.setText(String.valueOf(model.getPsfGibsonLanniMaxRadius()));
+        
     }
     
     private void initializeSimulationActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initializeSimulationActionPerformed
@@ -1466,12 +2021,12 @@ public class InitializeSimulation extends java.awt.Dialog {
     private void saveButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_saveButtonActionPerformed
         JFileChooser fc = new JFileChooser();
         int returnVal;
-        fc.setDialogType(JFileChooser.OPEN_DIALOG);
+        fc.setDialogType(JFileChooser.SAVE_DIALOG);
         //set a default filename
         fc.setSelectedFile(new File("simulation.sass"));
         //Set an extension filter
         fc.setFileFilter(new FileNameExtensionFilter("SASS settings","sass"));
-        returnVal = fc.showOpenDialog(null);
+        returnVal = fc.showSaveDialog(null);
         if  (returnVal != JFileChooser.APPROVE_OPTION) {
             return;
         }
@@ -1514,8 +2069,11 @@ public class InitializeSimulation extends java.awt.Dialog {
     private void emittersCsvButtonStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_emittersCsvButtonStateChanged
         if (emittersCsvButton.isSelected()) {
             emittersChooseFile.setEnabled(true);
+            emitters3DCheckBox.setSelected(false);
+            emitters3DCheckBox.setEnabled(false);
         } else {
             emittersChooseFile.setEnabled(false);
+            emitters3DCheckBox.setEnabled(true);
         }
     }//GEN-LAST:event_emittersCsvButtonStateChanged
 
@@ -1550,6 +2108,21 @@ public class InitializeSimulation extends java.awt.Dialog {
         }
     }//GEN-LAST:event_backgroundRandomButtonStateChanged
 
+    private void psfComboBoxItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_psfComboBoxItemStateChanged
+        CardLayout cl = (CardLayout)(psfCardPanel.getLayout());
+        cl.show(psfCardPanel, (String)evt.getItem());
+    }//GEN-LAST:event_psfComboBoxItemStateChanged
+
+    private void emitters3DCheckBoxItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_emitters3DCheckBoxItemStateChanged
+        if (emitters3DCheckBox.isSelected()) {
+            emitters3DMinZ.setEnabled(true);
+            emitters3DMaxZ.setEnabled(true);
+        } else {
+            emitters3DMinZ.setEnabled(false);
+            emitters3DMaxZ.setEnabled(false);
+        }
+    }//GEN-LAST:event_emitters3DCheckBoxItemStateChanged
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel analyzer_panel;
@@ -1577,6 +2150,9 @@ public class InitializeSimulation extends java.awt.Dialog {
     private javax.swing.JPanel controller_panel;
     private javax.swing.JTextField e_controller_tickrate;
     private javax.swing.JTextField e_max_controller_output;
+    private javax.swing.JCheckBox emitters3DCheckBox;
+    private javax.swing.JTextField emitters3DMaxZ;
+    private javax.swing.JTextField emitters3DMinZ;
     private javax.swing.ButtonGroup emittersButtons;
     private javax.swing.JButton emittersChooseFile;
     private javax.swing.JRadioButton emittersCsvButton;
@@ -1591,6 +2167,23 @@ public class InitializeSimulation extends java.awt.Dialog {
     private javax.swing.JTextField fluorophoreTOff;
     private javax.swing.JTextField fluorophoreTOn;
     private javax.swing.JTextField fluorophoreWavelength;
+    private javax.swing.JTextField glMaxRadius;
+    private javax.swing.JTextField glNg;
+    private javax.swing.JTextField glNg0;
+    private javax.swing.JTextField glNi;
+    private javax.swing.JTextField glNi0;
+    private javax.swing.JTextField glNs;
+    private javax.swing.JTextField glNumBasis;
+    private javax.swing.JTextField glNumSamples;
+    private javax.swing.JTextField glOversampling;
+    private javax.swing.JTextField glResPsf;
+    private javax.swing.JTextField glResPsfAxial;
+    private javax.swing.JTextField glSizeX;
+    private javax.swing.JTextField glSizeY;
+    private javax.swing.JTextField glSolver;
+    private javax.swing.JTextField glTg;
+    private javax.swing.JTextField glTg0;
+    private javax.swing.JTextField glTi0;
     private javax.swing.JButton initializeSimulation;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel10;
@@ -1650,9 +2243,47 @@ public class InitializeSimulation extends java.awt.Dialog {
     private javax.swing.JLabel jLabel6;
     private javax.swing.JLabel jLabel60;
     private javax.swing.JLabel jLabel61;
+    private javax.swing.JLabel jLabel62;
+    private javax.swing.JLabel jLabel63;
+    private javax.swing.JLabel jLabel64;
+    private javax.swing.JLabel jLabel65;
+    private javax.swing.JLabel jLabel66;
+    private javax.swing.JLabel jLabel67;
+    private javax.swing.JLabel jLabel68;
+    private javax.swing.JLabel jLabel69;
     private javax.swing.JLabel jLabel7;
+    private javax.swing.JLabel jLabel70;
+    private javax.swing.JLabel jLabel71;
+    private javax.swing.JLabel jLabel72;
+    private javax.swing.JLabel jLabel73;
+    private javax.swing.JLabel jLabel74;
+    private javax.swing.JLabel jLabel75;
+    private javax.swing.JLabel jLabel76;
+    private javax.swing.JLabel jLabel77;
+    private javax.swing.JLabel jLabel78;
+    private javax.swing.JLabel jLabel79;
     private javax.swing.JLabel jLabel8;
+    private javax.swing.JLabel jLabel80;
+    private javax.swing.JLabel jLabel81;
+    private javax.swing.JLabel jLabel82;
+    private javax.swing.JLabel jLabel83;
+    private javax.swing.JLabel jLabel84;
+    private javax.swing.JLabel jLabel85;
+    private javax.swing.JLabel jLabel86;
+    private javax.swing.JLabel jLabel87;
+    private javax.swing.JLabel jLabel88;
+    private javax.swing.JLabel jLabel89;
     private javax.swing.JLabel jLabel9;
+    private javax.swing.JLabel jLabel90;
+    private javax.swing.JLabel jLabel91;
+    private javax.swing.JLabel jLabel92;
+    private javax.swing.JLabel jLabel93;
+    private javax.swing.JLabel jLabel94;
+    private javax.swing.JLabel jLabel95;
+    private javax.swing.JLabel jLabel96;
+    private javax.swing.JLabel jLabel97;
+    private javax.swing.JLabel jLabel98;
+    private javax.swing.JLabel jLabel99;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JPanel jPanel3;
@@ -1662,6 +2293,8 @@ public class InitializeSimulation extends java.awt.Dialog {
     private javax.swing.JPanel jPanel7;
     private javax.swing.JPanel jPanel8;
     private javax.swing.JPanel jPanel9;
+    private javax.swing.JSeparator jSeparator1;
+    private javax.swing.JSeparator jSeparator2;
     private javax.swing.JTextField laserInitPower;
     private javax.swing.JTextField laserMaxPower;
     private javax.swing.JTextField laserMinPower;
@@ -1669,6 +2302,15 @@ public class InitializeSimulation extends java.awt.Dialog {
     private javax.swing.JTextField objectiveNa;
     private javax.swing.JButton openButton;
     private java.awt.Panel panel6;
+    private javax.swing.JPanel psfCardPanel;
+    private javax.swing.JComboBox<String> psfComboBox;
+    private javax.swing.JPanel psfGaussian2DCard;
+    private javax.swing.JLabel psfGaussian2DLabel;
+    private javax.swing.JPanel psfGaussian3DCard;
+    private javax.swing.JLabel psfGaussian3DLabel;
+    private javax.swing.JScrollPane psfGibsonLanniCard;
+    private javax.swing.JPanel psfGibsonLanniPanel;
+    private javax.swing.JPanel psfParentPanel;
     private javax.swing.JButton saveButton;
     private javax.swing.JTextField stageZ;
     // End of variables declaration//GEN-END:variables

--- a/src/ch/epfl/leb/sass/ijplugin/Model.java
+++ b/src/ch/epfl/leb/sass/ijplugin/Model.java
@@ -24,7 +24,7 @@ import ch.epfl.leb.sass.simulator.generators.realtime.components.Objective;
 import ch.epfl.leb.sass.simulator.generators.realtime.components.Stage;
 import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.dynamics.SimpleDynamics;
 import ch.epfl.leb.sass.simulator.generators.realtime.fluorophores.commands.*;
-import ch.epfl.leb.sass.simulator.generators.realtime.psfs.Gaussian2D;
+import ch.epfl.leb.sass.simulator.generators.realtime.psfs.*;
 import ch.epfl.leb.sass.simulator.generators.realtime.obstructors.commands.GenerateFiducialsRandom2D;
 import ch.epfl.leb.sass.simulator.generators.realtime.backgrounds.commands.*;
 import ij.IJ;
@@ -79,6 +79,9 @@ public class Model implements Serializable {
     private String emittersRandomButtonText;
     private String emittersGridButtonText;
     private String emittersCsvFileButtonText;
+    private boolean emitters3DCheckBoxEnabled;
+    private double emitters3DMinZ;
+    private double emitters3DMaxZ;
     
     private int fiducialsNumber;
     private double fiducialsSignal;
@@ -93,6 +96,28 @@ public class Model implements Serializable {
     private String backgroundRandomButtonText;
     private String backgroundUniformButtonText;
     private String backgroundTifFileButtonText;
+    
+    private String psfCurrentSelection;
+    private String psfGaussian2dText;
+    private String psfGaussian3dText;
+    private int psfGibsonLanniNumBasis;
+    private int psfGibsonLanniNumSamples;
+    private int psfGibsonLanniOversampling;
+    private int psfGibsonLanniSizeX;
+    private int psfGibsonLanniSizeY;
+    private double psfGibsonLanniNs;
+    private double psfGibsonLanniNg0;
+    private double psfGibsonLanniNg;
+    private double psfGibsonLanniNi0;
+    private double psfGibsonLanniNi;
+    private double psfGibsonLanniTi0;
+    private double psfGibsonLanniTg0;
+    private double psfGibsonLanniTg;
+    private double psfGibsonLanniResPsf;
+    private double psfGibsonLanniResPsfAxial;
+    private String psfGibsonLanniSolver;
+    private int psfGibsonLanniMaxRadius;
+    private String psfGibsonLanniText;
     
     // Getters
     //--------------------------------------------------------------------------
@@ -141,6 +166,11 @@ public class Model implements Serializable {
     public String getEmittersCsvFileButtonText() {
         return emittersCsvFileButtonText;
     }
+    public boolean getEmitters3DCheckBoxEnabled() {
+        return emitters3DCheckBoxEnabled;
+    }
+    public double getEmitters3DMinZ() { return emitters3DMinZ; }
+    public double getEmitters3DMaxZ() { return emitters3DMaxZ; }
     
     public int getFiducialsNumber() { return fiducialsNumber; }
     public double getFiducialsSignal() { return fiducialsSignal;}
@@ -148,32 +178,44 @@ public class Model implements Serializable {
     public String getBackgroundCurrentSelection() {
         return backgroundCurrentSelection;
     }
-    public float getBackgroundUniformSignal() {
-        return backgroundUniformSignal;
-    }
+    public float getBackgroundUniformSignal() { return backgroundUniformSignal; }
     public String getBackgroundUniformButtonText() {
         return backgroundUniformButtonText;
     }
     public double getBackgroundRandomFeatureSize() {
         return backgroundRandomFeatureSize;
     }
-    public float getBackgroundRandomMinValue() {
-        return backgroundRandomMinValue;
-    }
-    public float getBackgroundRandomMaxValue() {
-        return backgroundRandomMaxValue;
-    }
-    public int getBackgroundRandomSeed() {
-        return backgroundRandomSeed;
-    }
+    public float getBackgroundRandomMinValue() { return backgroundRandomMinValue; }
+    public float getBackgroundRandomMaxValue() { return backgroundRandomMaxValue; }
+    public int getBackgroundRandomSeed() { return backgroundRandomSeed; }
     public String getBackgroundRandomButtonText() {
-        return backgroundRandomButtonText;
-    }
-    public String getBackgroundTifFile() {
-        return backgroundTifFile;
-    }
+        return backgroundRandomButtonText;}
+    public String getBackgroundTifFile() { return backgroundTifFile; }
     public String getBackgroundTifFileButtonText() {
         return backgroundTifFileButtonText;
+    }
+    public String getPsfCurrentSelection() { return psfCurrentSelection; }
+    public String getPsfGaussian2dText() { return psfGaussian2dText; }
+    public String getPsfGaussian3dText() { return psfGaussian3dText; }
+    public int getPsfGibsonLanniNumBasis() { return psfGibsonLanniNumBasis; }
+    public int getPsfGibsonLanniNumSamples() { return psfGibsonLanniNumSamples; }
+    public int getPsfGibsonLanniOversampling() { return psfGibsonLanniOversampling; }
+    public int getPsfGibsonLanniSizeX() { return psfGibsonLanniSizeX; }
+    public int getPsfGibsonLanniSizeY() { return psfGibsonLanniSizeY; }
+    public double getPsfGibsonLanniNs() { return psfGibsonLanniNs; }
+    public double getPsfGibsonLanniNg0() { return psfGibsonLanniNg0; }
+    public double getPsfGibsonLanniNg() { return psfGibsonLanniNg; }
+    public double getPsfGibsonLanniNi0() { return psfGibsonLanniNi0; }
+    public double getPsfGibsonLanniNi() { return psfGibsonLanniNi; }
+    public double getPsfGibsonLanniTi0() { return psfGibsonLanniTi0; }
+    public double getPsfGibsonLanniTg0() { return psfGibsonLanniTg0; }
+    public double getPsfGibsonLanniTg() { return psfGibsonLanniTg; }
+    public double getPsfGibsonLanniResPsf() { return psfGibsonLanniResPsf; }
+    public double getPsfGibsonLanniResPsfAxial() { return psfGibsonLanniResPsfAxial; }
+    public String getPsfGibsonLanniSolver() { return psfGibsonLanniSolver; }
+    public int getPsfGibsonLanniMaxRadius() { return psfGibsonLanniMaxRadius; }
+    public String getPsfGibsonLanniText() {
+        return psfGibsonLanniText;
     }
     
     // Setters
@@ -245,6 +287,15 @@ public class Model implements Serializable {
     public void setEmittersCsvFileButtonText(String text) {
         emittersCsvFileButtonText = text;
     }
+    public void setEmitters3DCheckBoxEnabled(boolean enabled) {
+        emitters3DCheckBoxEnabled = enabled;
+    }
+    public void setEmitters3DMinZ(double min) {
+        emitters3DMinZ = min;
+    }
+    public void setEmitters3DMaxZ(double max) {
+        emitters3DMaxZ = max;
+    }
     
     public void setFiducialsNumber(int number) {
         fiducialsNumber = number;
@@ -282,6 +333,48 @@ public class Model implements Serializable {
     public void setBackgroundTifFileButtonText(String text) {
         backgroundTifFileButtonText = text;
     }
+    public void setPsfCurrentSelection(String text) {
+        psfCurrentSelection = text;
+    }
+    public void setPsfGaussian2dText(String text) {
+        psfGaussian2dText = text;
+    }
+    public void setPsfGaussian3dText(String text) {
+        psfGaussian3dText = text;
+    }
+    public void setPsfGibsonLanniNumBasis(int numBasis) {
+        psfGibsonLanniNumBasis = numBasis;
+    }
+    public void setPsfGibsonLanniNumSamples(int numSamples) {
+        psfGibsonLanniNumSamples = numSamples;
+    }
+    public void setPsfGibsonLanniOversampling(int oversampling) {
+        psfGibsonLanniOversampling = oversampling; }
+    public void setPsfGibsonLanniSizeX(int sizeX) {  psfGibsonLanniSizeX = sizeX; }
+    public void setPsfGibsonLanniSizeY(int sizeY) {  psfGibsonLanniSizeY = sizeY; }
+    public void setPsfGibsonLanniNs(double ns) {  psfGibsonLanniNs = ns; }
+    public void setPsfGibsonLanniNg0(double ng0) { psfGibsonLanniNg0 = ng0; }
+    public void setPsfGibsonLanniNg(double ng) {  psfGibsonLanniNg = ng; }
+    public void setPsfGibsonLanniNi0(double ni0) {  psfGibsonLanniNi0 = ni0; }
+    public void setPsfGibsonLanniNi(double ni) {  psfGibsonLanniNi =  ni; }
+    public void setPsfGibsonLanniTi0(double ti0) {  psfGibsonLanniTi0 = ti0; }
+    public void setPsfGibsonLanniTg0(double tg0) {  psfGibsonLanniTg0 = tg0; }
+    public void setPsfGibsonLanniTg(double tg) {  psfGibsonLanniTg = tg; }
+    public void setPsfGibsonLanniResPsf(double resPsf) {
+        psfGibsonLanniResPsf = resPsf;
+    }
+    public void setPsfGibsonLanniResPsfAxial(double resPsfAxial) {
+        psfGibsonLanniResPsfAxial = resPsfAxial;
+    }
+    public void setPsfGibsonLanniSolver(String solver) {
+        psfGibsonLanniSolver = solver;
+    }
+    public void setPsfGibsonLanniMaxRadius(int maxRadius) {
+        psfGibsonLanniMaxRadius = maxRadius;
+    }
+    public void setPsfGibsonLanniText(String text) {
+        psfGibsonLanniText = text;
+    }
     
     /**
      * Builds a microscope from the model parameters.
@@ -293,7 +386,7 @@ public class Model implements Serializable {
         Stage.Builder stageBuilder = new Stage.Builder();
         SimpleDynamics.Builder fluorPropBuilder = new SimpleDynamics.Builder();
         Laser.Builder laserBuilder = new Laser.Builder();
-        Gaussian2D.Builder psfBuilder = new Gaussian2D.Builder();
+        PSFBuilder psfBuilder = null;
         FluorophoreCommandBuilder fluorPosBuilder = null;
         GenerateFiducialsRandom2D.Builder fidBuilder = 
                 new GenerateFiducialsRandom2D.Builder();
@@ -329,8 +422,8 @@ public class Model implements Serializable {
         laserBuilder.minPower(laserMinPower);
         laserBuilder.maxPower(laserMaxPower);
 
-        if (emittersCurrentSelection.equals(emittersRandomButtonText)) {
-            // Random fluorophore distributions
+        if (emittersCurrentSelection.equals(emittersRandomButtonText) & !(emitters3DCheckBoxEnabled)) {
+            // Random 2D fluorophore distributions
             try {
                 GenerateFluorophoresRandom2D.Builder tempPosBuilder = new GenerateFluorophoresRandom2D.Builder();
                 tempPosBuilder.numFluors(emittersRandomNumber);
@@ -338,8 +431,8 @@ public class Model implements Serializable {
             } catch (Exception ex) {
                 IJ.showMessage("Error in emitter position parsing.");
             }
-        } else if (emittersCurrentSelection.equals(emittersGridButtonText)) {
-            // Fluorophore distributions on a square grid
+        } else if (emittersCurrentSelection.equals(emittersGridButtonText) & !(emitters3DCheckBoxEnabled)) {
+            // Fluorophore distributions in 2D on a square grid
             try {
                 GenerateFluorophoresGrid2D.Builder tempPosBuilder = new GenerateFluorophoresGrid2D.Builder();
                 tempPosBuilder.spacing(emittersGridSpacing);
@@ -347,6 +440,28 @@ public class Model implements Serializable {
             } catch (Exception ex) {
                 IJ.showMessage("Error in emitter position parsing.");
             }
+        } else if (emittersCurrentSelection.equals(emittersRandomButtonText) & emitters3DCheckBoxEnabled) {
+            // Random 3D fluorophore distributions
+            try {
+                GenerateFluorophoresRandom3D.Builder tempPosBuilder = new GenerateFluorophoresRandom3D.Builder();
+                tempPosBuilder.numFluors(emittersRandomNumber);
+                tempPosBuilder.zLow(emitters3DMinZ);
+                tempPosBuilder.zHigh(emitters3DMaxZ);
+                fluorPosBuilder = tempPosBuilder;
+            } catch (Exception ex) {
+                IJ.showMessage("Error in emitter position parsing.");
+            }
+        } else if (emittersCurrentSelection.equals(emittersGridButtonText) & !(emitters3DCheckBoxEnabled)) {
+            // Fluorophore distributions in 3D on a square grid
+            try {
+                GenerateFluorophoresGrid3D.Builder tempPosBuilder = new GenerateFluorophoresGrid3D.Builder();
+                tempPosBuilder.spacing(emittersGridSpacing);
+                tempPosBuilder.zLow(emitters3DMinZ);
+                tempPosBuilder.zHigh(emitters3DMaxZ);
+                fluorPosBuilder = tempPosBuilder;
+            } catch (Exception ex) {
+                IJ.showMessage("Error in emitter position parsing.");
+            } 
         } else if (emittersCurrentSelection.equals(emittersCsvFileButtonText)) {
             // Parse fluorophore positions from a CSV file
             GenerateFluorophoresFromCSV.Builder tempPosBuilder = new GenerateFluorophoresFromCSV.Builder();
@@ -388,6 +503,33 @@ public class Model implements Serializable {
             } catch (Exception ex) {
                 IJ.showMessage("Error in device component intialization.");
             }
+        }
+        
+        if (psfCurrentSelection.equals(psfGaussian2dText)) {
+            psfBuilder = new Gaussian2D.Builder();
+        } else if (psfCurrentSelection.equals(psfGaussian3dText)) {
+            psfBuilder = new Gaussian3D.Builder();
+        } else if (psfCurrentSelection.equals(psfGibsonLanniText)) {
+            GibsonLanniPSF.Builder tempBuilder = new GibsonLanniPSF.Builder();
+            tempBuilder.numBasis(psfGibsonLanniNumBasis)
+                    .numSamples(psfGibsonLanniNumSamples)
+                    .oversampling(psfGibsonLanniOversampling)
+                    .sizeX(psfGibsonLanniSizeX)
+                    .sizeY(psfGibsonLanniSizeY)
+                    .ns(psfGibsonLanniNs)
+                    .ng0(psfGibsonLanniNg0)
+                    .ng(psfGibsonLanniNg)
+                    .ni0(psfGibsonLanniNi0)
+                    .ni(psfGibsonLanniNi)
+                    .ti0(psfGibsonLanniTi0)
+                    .tg0(psfGibsonLanniTg0)
+                    .tg(psfGibsonLanniTg)
+                    .resPSF(psfGibsonLanniResPsf)
+                    .resPSFAxial(psfGibsonLanniResPsfAxial)
+                    .solver(psfGibsonLanniSolver)
+                    .maxRadius(psfGibsonLanniMaxRadius);
+            psfBuilder = tempBuilder;
+            
         }
         
         return new Microscope(

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Microscope.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Microscope.java
@@ -37,6 +37,7 @@ import ij.process.ShortProcessor;
 import java.util.Arrays;
 import java.util.List;
 import cern.jet.random.Poisson;
+import ij.IJ;
 
 /**
  * Integrates all the components into one microscope.
@@ -101,7 +102,6 @@ public class Microscope {
                   .FWHM(fwhm)
                   .wavelength(wavelength)
                   .resLateral(camera.getPixelSize() / objective.getMag());
-        
         // Create the set of fluorophores.
         positionBuilder.camera(camera)
                        .psfBuilder(psfBuilder)

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/psfs/GibsonLanniPSF.java
@@ -195,6 +195,9 @@ public final class GibsonLanniPSF implements PSF {
     
     /**
      * Cache for PSF  interpolators.
+     * 
+     * This is cleared every time a new Builder is created to prevent problems
+     * when parameters change between simulations.
      */
     private static HashMap<Long, PiecewiseBicubicSplineInterpolatingFunction>
                         interpolators = new HashMap<>();
@@ -226,6 +229,13 @@ public final class GibsonLanniPSF implements PSF {
         private double maxRadius;
         private double stageDisplacement;
         private String solver;
+        
+        public Builder() {
+        // Clear the cache every time a new Builder is created.
+        // This prevents erroneous calculations in new simulations with
+        // with different values for the stage displacement.
+        interpolators = new HashMap<>();
+        }
         
         public Builder numBasis(int numBasis) {
             this.numBasis = numBasis;

--- a/test/ch/epfl/leb/sass/ijplugin/ModelTest.java
+++ b/test/ch/epfl/leb/sass/ijplugin/ModelTest.java
@@ -419,6 +419,45 @@ public class ModelTest {
         String result = instance.getEmittersCsvFileButtonText();
         assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getEmitters3DCheckBoxEnabled method, of class Model.
+     */
+    @Test
+    public void testGetEmitters3DCheckBoxEnabled() {
+        System.out.println("getEmitters3DCheckBoxEnabled");
+        Model instance = new Model();
+        boolean expResult = true;
+        instance.setEmitters3DCheckBoxEnabled(expResult);
+        boolean result = instance.getEmitters3DCheckBoxEnabled();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getEmitters3DMinZ method, of class Model.
+     */
+    @Test
+    public void testGetEmitters3DMinZ() {
+        System.out.println("getEmitters3DMinZ");
+        Model instance = new Model();
+        double expResult = 0.0;
+        instance.setEmitters3DMinZ(expResult);
+        double result = instance.getEmitters3DMinZ();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getEmitters3DMaxZ method, of class Model.
+     */
+    @Test
+    public void testGetEmitters3DMaxZ() {
+        System.out.println("getEmitters3DMaxZ");
+        Model instance = new Model();
+        double expResult = 3.2;
+        instance.setEmitters3DMaxZ(expResult);
+        double result = instance.getEmitters3DMaxZ();
+        assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of getFiducialsNumber method, of class Model.
@@ -575,5 +614,265 @@ public class ModelTest {
         instance.setBackgroundTifFileButtonText(expResult);
         String result = instance.getBackgroundTifFileButtonText();
         assertEquals(expResult, result);
-    }    
+    }
+    
+    /**
+     * Test of getPsfCurrentSelection method, of class Model.
+     */
+    @Test
+    public void testGetPsfCurrentSelection() {
+        System.out.println("getPsfCurrentSelection");
+        Model instance = new Model();
+        String expResult = "Gaussian 2D";
+        instance.setPsfCurrentSelection(expResult);
+        String result = instance.getPsfCurrentSelection();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGaussian2dText method, of class Model.
+     */
+    @Test
+    public void testGetPsfGaussian2dText() {
+        System.out.println("getPsfGaussian2dText");
+        Model instance = new Model();
+        String expResult = "Gaussian 2D";
+        instance.setPsfGaussian2dText(expResult);
+        String result = instance.getPsfGaussian2dText();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGaussian3dText method, of class Model.
+     */
+    @Test
+    public void testGetPsfGaussian3dText() {
+        System.out.println("getPsfGaussian3dText");
+        Model instance = new Model();
+        String expResult = "Gaussian 3D";
+        instance.setPsfGaussian3dText(expResult);
+        String result = instance.getPsfGaussian3dText();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNumBasis, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNumBasis() {
+        System.out.println("getPsfGibsonLanniNumBasis");
+        Model instance = new Model();
+        int expResult = 100;
+        instance.setPsfGibsonLanniNumBasis(expResult);
+        int result = instance.getPsfGibsonLanniNumBasis();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNumSamples, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNumSamples() {
+        System.out.println("getPsfGibsonLanniNumSamples");
+        Model instance = new Model();
+        int expResult = 1000;
+        instance.setPsfGibsonLanniNumSamples(expResult);
+        int result = instance.getPsfGibsonLanniNumSamples();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniOversampling, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniOversampling() {
+        System.out.println("getPsfGibsonLanniOversampling");
+        Model instance = new Model();
+        int expResult = 2;
+        instance.setPsfGibsonLanniOversampling(expResult);
+        int result = instance.getPsfGibsonLanniOversampling();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniSizeX, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniSizeX() {
+        System.out.println("getPsfGibsonLanniSizeX");
+        Model instance = new Model();
+        int expResult = 32;
+        instance.setPsfGibsonLanniSizeX(expResult);
+        int result = instance.getPsfGibsonLanniSizeX();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniSizeY, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniSizeY() {
+        System.out.println("getPsfGibsonLanniSizeY");
+        Model instance = new Model();
+        int expResult = 32;
+        instance.setPsfGibsonLanniSizeY(expResult);
+        int result = instance.getPsfGibsonLanniSizeY();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNs, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNs() {
+        System.out.println("getPsfGibsonLanniNs");
+        Model instance = new Model();
+        double expResult = 1.33;
+        instance.setPsfGibsonLanniNs(expResult);
+        double result = instance.getPsfGibsonLanniNs();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNg0, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNg0() {
+        System.out.println("getPsfGibsonLanniNg0");
+        Model instance = new Model();
+        double expResult = 1.5;
+        instance.setPsfGibsonLanniNg0(expResult);
+        double result = instance.getPsfGibsonLanniNg0();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNg, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNg() {
+        System.out.println("getPsfGibsonLanniNg");
+        Model instance = new Model();
+        double expResult = 1.5;
+        instance.setPsfGibsonLanniNg(expResult);
+        double result = instance.getPsfGibsonLanniNg();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNi0, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNi0() {
+        System.out.println("getPsfGibsonLanniNi0");
+        Model instance = new Model();
+        double expResult = 1.5;
+        instance.setPsfGibsonLanniNi0(expResult);
+        double result = instance.getPsfGibsonLanniNi0();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniNi, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniNi() {
+        System.out.println("getPsfGibsonLanniNi");
+        Model instance = new Model();
+        double expResult = 1.5;
+        instance.setPsfGibsonLanniNi(expResult);
+        double result = instance.getPsfGibsonLanniNi();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniTi0, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniTi0() {
+        System.out.println("getPsfGibsonLanniTi0");
+        Model instance = new Model();
+        double expResult = 150;
+        instance.setPsfGibsonLanniTi0(expResult);
+        double result = instance.getPsfGibsonLanniTi0();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniTg0, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniTg0() {
+        System.out.println("getPsfGibsonLanniTg0");
+        Model instance = new Model();
+        double expResult = 170;
+        instance.setPsfGibsonLanniTg0(expResult);
+        double result = instance.getPsfGibsonLanniTg0();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniTg, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniTg() {
+        System.out.println("getPsfGibsonLanniTg");
+        Model instance = new Model();
+        double expResult = 170;
+        instance.setPsfGibsonLanniTg(expResult);
+        double result = instance.getPsfGibsonLanniTg();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniResPsf, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniResPsf() {
+        System.out.println("getPsfGibsonLanniResPsf");
+        Model instance = new Model();
+        double expResult = 0.0215;
+        instance.setPsfGibsonLanniResPsf(expResult);
+        double result = instance.getPsfGibsonLanniResPsf();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniResPsfAxial, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniResPsfAxial() {
+        System.out.println("getPsfGibsonLanniResPsfAxial");
+        Model instance = new Model();
+        double expResult = 0.005;
+        instance.setPsfGibsonLanniResPsfAxial(expResult);
+        double result = instance.getPsfGibsonLanniResPsfAxial();
+        assertEquals(expResult, result, 0.0);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniSolver, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniSolver() {
+        System.out.println("getPsfGibsonLanniSolver");
+        Model instance = new Model();
+        String expResult = "svd";
+        instance.setPsfGibsonLanniSolver(expResult);
+        String result = instance.getPsfGibsonLanniSolver();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getPsfGibsonLanniMaxRadius, of class Model.
+     */
+    @Test
+    public void testGetPsfGibsonLanniMaxRadius() {
+        System.out.println("getPsfGibsonLanniMaxRadius");
+        Model instance = new Model();
+        int expResult = 15;
+        instance.setPsfGibsonLanniMaxRadius(expResult);
+        int result = instance.getPsfGibsonLanniMaxRadius();
+        assertEquals(expResult, result);
+    }
 }


### PR DESCRIPTION
### Added
- You can now save and load simulation settings from the GUI.

### Fixed
- Fixed a cropping issue with the self-tuning PI controller dialog on Linux.
- The `GibsonLanniPSF` cache is now erased everytime a new builder is created for this PSF type. This prevents caching calculations done for previous simulations.
- The Save... button in the Initialize Simulation window is now properly displayed as a Save dialog.