### PR TITLE
Fix loggers save bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Contains [ALICA v0.2.4]
 - The latency bug that caused a pause during every tenth simulation
   frame in GUI mode has been fixed. The latency came from updating the
   original status plots, which have been changed in this version.
+- Loggers now properly check for filename collisions to prevent
+  overwriting previously saved data.
 
 ## [v0.5.1]
 

--- a/src/ch/epfl/leb/sass/simulator/loggers/AbstractLogger.java
+++ b/src/ch/epfl/leb/sass/simulator/loggers/AbstractLogger.java
@@ -18,6 +18,8 @@
 package ch.epfl.leb.sass.simulator.loggers;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.FileSystems;
 import java.io.IOException;
 
 /**
@@ -80,7 +82,13 @@ public abstract class AbstractLogger {
             if (2 == tokens.length)
                 baseName += "." + tokens[1];
             
-            baseName = logFile.getParent() + File.separator + baseName;
+            String parent = logFile.getParent();
+            if (parent == null) {
+                // Get current working directory in case no path was supplied
+                Path path = FileSystems.getDefault().getPath(".");
+                parent = path.toString();
+            }
+            baseName = parent + File.separator + baseName;
             logFile = new File(baseName);
             fileId++;
         }


### PR DESCRIPTION
### Fixed
- Loggers now properly check for filename collisions to prevent overwriting previously saved data.

This is intended to fix #29 