### PR TITLE
Fix off-by-one error in the live view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 - The `FluorophoreDynamics`-related classes were moved into their own,
   new `photophysics` package.
   
+### Fixed
+- Off-by-one error in the ImageJ plugin's live view window.
+  
 ### Removed
 - `getSimulationState()` method of interface `Simulator`
 - `StateLogger`, `PositionLogger`, and `FrameLogger` were

--- a/src/main/java/ch/epfl/leb/sass/ijplugin/App.java
+++ b/src/main/java/ch/epfl/leb/sass/ijplugin/App.java
@@ -212,7 +212,7 @@ class Worker extends Thread {
                 stop = true;
             }
             
-            imp.setSlice(imp.getSize() - 1);
+            imp.setSlice(imp.getSize());
             imp.updateView();
             try {
                 sleep(20);


### PR DESCRIPTION
### Fixed
- Off-by-one error in the ImageJ plugin's live view window.

Fixes #82 